### PR TITLE
Change the type of branch protection blocks from array to object

### DIFF
--- a/examples/public-repository-complete-example/main.tf
+++ b/examples/public-repository-complete-example/main.tf
@@ -76,23 +76,23 @@ module "repository" {
       enforce_admins         = true
       require_signed_commits = true
 
-      required_status_checks = [{
+      required_status_checks = {
         strict   = true
         contexts = ["ci/travis"]
-      }]
+      }
 
-      required_pull_request_reviews = [{
+      required_pull_request_reviews = {
         dismiss_stale_reviews           = true
         dismissal_users                 = ["terraform-test-user-1"]
         dismissal_teams                 = [github_team.team.slug]
         require_code_owner_reviews      = true
         required_approving_review_count = 1
-      }]
+      }
 
-      restrictions = [{
+      restrictions = {
         users = ["terraform-test-user"]
         teams = ["team-1"]
-      }]
+      }
     }
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -16,47 +16,46 @@ locals {
   topics             = concat(local.standard_topics, var.extra_topics)
 }
 
-
 locals {
   branch_protection_rules = [
     for b in var.branch_protection_rules : merge({
       branch                        = null
       enforce_admins                = null
       require_signed_commits        = null
-      required_status_checks        = []
-      required_pull_request_reviews = []
-      restrictions                  = []
+      required_status_checks        = {}
+      required_pull_request_reviews = {}
+      restrictions                  = {}
     }, b)
   ]
 
   required_status_checks = [
-    for b in local.branch_protection_rules : [
-      for r in b.required_status_checks : merge({
+    for b in local.branch_protection_rules :
+    length(keys(b.required_status_checks)) > 0 ? [
+      merge({
         strict   = null
         contexts = []
-      }, r)
-    ]
+    }, b.required_status_checks)] : []
   ]
 
   required_pull_request_reviews = [
-    for b in local.branch_protection_rules : [
-      for r in b.required_pull_request_reviews : merge({
+    for b in local.branch_protection_rules :
+    length(keys(b.required_pull_request_reviews)) > 0 ? [
+      merge({
         dismiss_stale_reviews           = true
         dismissal_users                 = []
         dismissal_teams                 = []
         require_code_owner_reviews      = null
         required_approving_review_count = null
-      }, r)
-    ]
+    }, b.required_pull_request_reviews)] : []
   ]
 
   restrictions = [
-    for b in local.branch_protection_rules : [
-      for r in b.restrictions : merge({
+    for b in local.branch_protection_rules :
+    length(keys(b.restrictions)) > 0 ? [
+      merge({
         users = []
         teams = []
-      }, r)
-    ]
+    }, b.restrictions)] : []
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -166,7 +166,7 @@ variable "pull_team_ids" {
 }
 
 variable "branch_protection_rules" {
-  type = list(any)
+  type = any
 
   # We can't use a detailed type specification due to a terraform limitation. However, this might be changed in a future
   # Terraform version. See https://github.com/hashicorp/terraform/issues/19898 and https://github.com/hashicorp/terraform/issues/22449
@@ -202,23 +202,23 @@ variable "branch_protection_rules" {
   #     enforce_admins         = true
   #     require_signed_commits = true
   #
-  #     required_status_checks = [{
+  #     required_status_checks = {
   #       strict   = false
   #       contexts = ["ci/travis"]
-  #     }]
+  #     }
   #
-  #     required_pull_request_reviews = [{
+  #     required_pull_request_reviews = {
   #       dismiss_stale_reviews           = true
   #       dismissal_users                 = ["user1", "user2"]
   #       dismissal_teams                 = ["team-slug-1", "team-slug-2"]
   #       require_code_owner_reviews      = true
   #       required_approving_review_count = 1
-  #     }]
+  #     }
   #
-  #     restrictions = [{
+  #     restrictions = {
   #       users = ["user1"]
   #       teams = ["team-slug-1"]
-  #     }]
+  #     }
   #   }
   # ]
 }


### PR DESCRIPTION
As you can only have one block of the different objects in branch protections
it does not make sense to have type list here.

this is a breaking change