### PR TITLE
Add more features and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Default is `false`.
 The list of topics of the repository.
 Default is `[]`.
 
-- **[`template`](#template-object-arguments)**: *(Optional `object`)*
+- **[`template`](#template-object-attributes)**: *(Optional `object`)*
 Use a template repository to create this resource.
 See [Template Object Arguments](#template-object-arguments) below for details.
 
@@ -169,12 +169,47 @@ Default is `[]`.
 A list of user names to add as collaborators granting them pull (read-only) permission.
 Default is `[]`.
 
-#### [`template`](#repository-configuration) Object Arguments
+##### Deploy Key Configuration
+
+- **[`deploy_keys`](#deploy_keys-object-attributes)**: *(Optional `list(object|string)`)*
+Specifies deploy keys and access-level of deploy keys used in this repository.
+Every `string` in the list will be converted internally into the `object`
+representation with the `key` argument being set to the `string`.
+`object` details are explained below.
+Default is `[]`.
+
+- **[`deploy_keys_computed`](#deploy_keys-object-attributes)**: *(Optional `list(object|string)`)*
+Use this argument if you depend on computed keys that terraform can not use in
+resource `for_each` execution. Downside of this is the recreation of deploy key
+resources whenever the order in the list changes. Prefer `deploy_keys` whenever possible.
+This argument does **not** conflict with `deploy_keys` and can be used only for computed resources.
+Default is `[]`.
+
+#### [`template`](#repository-configuration) Object Attributes
 - **`owner`**: ***(Required `string`)***
 The GitHub organization or user the template repository is owned by.
 
 - **`repository`**: ***(Required `string`)***
 The name of the template repository.
+
+#### [`deploy_keys`](#repository-configuration) Object Attributes
+- **`key`**: ***(Required `string`)***
+The SSH public key.
+
+- **`title`**: *(Optional `string`)*
+A Title for the key.
+Default is the comment field of SSH public key if it is not empty else it defaults to
+`md5(key)`.
+
+- **`read_only`**: *(Optional `bool`)*
+Specifies teh level of access for the key.
+Default is `true`.
+
+- *`id`*: *(Optional `string`)*
+Specifies an ID which is used to prevent resource recreation when the order in
+the list of deploy keys changes.
+The ID must be unique between `deploy_keys` and `deploy_keys_computed`.
+Default is `md5(key)`.
 
 ## Module Attributes Reference
 The following attributes are exported by the module:
@@ -187,10 +222,14 @@ containing all arguments as specified above and the other attributes as specifie
 - **`ssh_clone_url`**: URL that can be provided to git clone to clone the repository via SSH.
 - **`http_clone_url`**: URL that can be provided to git clone to clone the repository via HTTPS.
 - **`git_clone_url`**: URL that can be provided to git clone to clone the repository anonymously via the git protocol.
+
 - **`collaborators`**: A map of Collaborator objects keyed by the `name` of the collaborator as returned by the
 [`github_repository_collaborator` resource](https://www.terraform.io/docs/providers/github/r/repository_collaborator.html#attribute-reference).
-- **`deploy_keys`**: A map of deploy key objects keyed by the `id` of the key as returned by the
-[`github_repository_project` resource](https://www.terraform.io/docs/providers/github/r/repository_project.html#attributes-reference).
+
+- **`deploy_keys`**: A merged map of deploy key objects for the keys originally passed via `deploy_keys` and `deploy_keys_computed` as returned by the
+[`github_repository_deploy_key` resource](https://www.terraform.io/docs/providers/github/r/repository_deploy_key.html#attributes-reference)
+keyed by the input `id` of the key.
+
 - **`projects`**: A map of Project objects keyed by the `id` of the project as returned by the
 [`github_repository_project` resource](https://www.terraform.io/docs/providers/github/r/repository_project.html#attributes-reference).
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ module "repository" {
 
 ## Module Argument Reference
 See
-[https://github.com/mineiros-io/terraform-github-repository/blob/master/variables.tf](variables.tf)
+[variables.tf](https://github.com/mineiros-io/terraform-github-repository/blob/master/variables.tf)
 and
-[https://github.com/mineiros-io/terraform-github-repository/blob/master/examples/](examples)
+[examples/](https://github.com/mineiros-io/terraform-github-repository/blob/master/examples)
 for details and use-cases.
 
 #### Top-level Arguments
@@ -123,18 +123,6 @@ Default is `false`
 Set to `true` to enable the (deprecated) downloads features on the repository.
 Default is `false`.
 
-- **`auto_init`**: *(Optional `bool`)*
-Set to `false` to not produce an initial commit in the repository.
-Default is `true`.
-
-- **`gitignore_template`**: *(Optional `string`)*
-Use the name of the template without the extension.
-Default is `""`
-
-- **`license_template`**: *(Optional `string`)*
-Use the name of the template without the extension.
-Default is `""`
-
 - **`default_branch`**: *(Optional `string`)*
 The name of the default branch of the repository.
 NOTE: This can only be set after a repository has already been created, and
@@ -152,30 +140,55 @@ Default is `false`.
 The list of topics of the repository.
 Default is `[]`.
 
+##### Repository Creation Configuration
+The following four arguments can only be set at repository creation and
+changes will be ignored for repository updates and
+will not show a diff in plan or apply phase.
+
+- **`auto_init`**: *(Optional `bool`)*
+Set to `false` to not produce an initial commit in the repository.
+Default is `true`.
+
+- **`gitignore_template`**: *(Optional `string`)*
+Use the name of the template without the extension.
+Default is `""`
+
+- **`license_template`**: *(Optional `string`)*
+Use the name of the template without the extension.
+Default is `""`
+
 - **[`template`](#template-object-attributes)**: *(Optional `object`)*
 Use a template repository to create this resource.
-See [Template Object Arguments](#template-object-arguments) below for details.
+See [Template Object Attributes](#template-object-attributes) below for details.
 
 ##### Collaborator Configuration
 
-- **`admin_collaborators`**: *(Optional `list(string)`)*
-A list of user names to add as collaborators granting them admin (full) permission.
-Default is `[]`.
-
-- **`push_collaborators`**: *(Optional `list(string)`)*
-A list of user names to add as collaborators granting them push (read-write) permission.
-Default is `[]`.
-
 - **`pull_collaborators`**: *(Optional `list(string)`)*
 A list of user names to add as collaborators granting them pull (read-only) permission.
+Recommended for non-code contributors who want to view or discuss your project.
 Default is `[]`.
 
 - **`triage_collaborators`**: *(Optional `list(string)`)*
 A list of user names to add as collaborators granting them triage permission.
+Recommended for contributors who need to proactively manage issues and pull requests
+without write access.
+Default is `[]`.
+
+- **`push_collaborators`**: *(Optional `list(string)`)*
+A list of user names to add as collaborators granting them push (read-write) permission.
+Recommended for contributors who actively push to your project.
 Default is `[]`.
 
 - **`maintain_collaborators`**: *(Optional `list(string)`)*
 A list of user names to add as collaborators granting them maintain permission.
+Recommended for project managers who need to manage the repository without access
+to sensitive or destructive actions.
+Default is `[]`.
+
+- **`admin_collaborators`**: *(Optional `list(string)`)*
+A list of user names to add as collaborators granting them admin (full) permission.
+Recommended for people who need full access to the project, including sensitive
+and destructive actions like managing security or deleting a repository.
 Default is `[]`.
 
 ##### Deploy Key Configuration
@@ -201,7 +214,7 @@ The GitHub organization or user the template repository is owned by.
 - **`repository`**: ***(Required `string`)***
 The name of the template repository.
 
-#### [`deploy_keys`](#repository-configuration) Object Attributes
+#### [`deploy_keys`](#deploy-key-configuration) Object Attributes
 - **`key`**: ***(Required `string`)***
 The SSH public key.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://mineiros.semaphoreci.com/badges/terraform-github-repository/branches/master.svg?style=shields)](https://mineiros.semaphoreci.com/badges/terraform-github-repository/branches/master.svg?style=shields)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/mineiros-io/terraform-github-repository.svg?label=latest&sort=semver)](https://github.com/mineiros-io/terraform-github-repository/releases)
 [![Terraform Version](https://img.shields.io/badge/terraform-~%3E%200.12.20-brightgreen.svg)](https://github.com/hashicorp/terraform/releases)
+[![Github Provider Version](https://img.shields.io/badge/github--provider-%3E%3D%202.3.1-brightgreen.svg)](https://github.com/terraform-providers/terraform-provider-github/releases)
 [![License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # terraform-github-repository
@@ -167,6 +168,14 @@ Default is `[]`.
 
 - **`pull_collaborators`**: *(Optional `list(string)`)*
 A list of user names to add as collaborators granting them pull (read-only) permission.
+Default is `[]`.
+
+- **`triage_collaborators`**: *(Optional `list(string)`)*
+A list of user names to add as collaborators granting them triage permission.
+Default is `[]`.
+
+- **`maintain_collaborators`**: *(Optional `list(string)`)*
+A list of user names to add as collaborators granting them maintain permission.
 Default is `[]`.
 
 ##### Deploy Key Configuration

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ features like Branch Protection or Collaborator Management.
 - **Extended S3 Features**:
   Branch Protection,
   Issue Labels,
+  Handle Github Default Issue Labels,
   Collaborators,
   Teams,
   Deploy Keys,
@@ -49,7 +50,6 @@ features like Branch Protection or Collaborator Management.
 
 - *Features not yet implemented*:
   Repository Webhooks,
-  Handle Github Defauls Issue Labels,
   Project Columns support
 
 ## Getting Started
@@ -235,6 +235,11 @@ This resource will first check if the label exists, and then issue an update,
 otherwise it will create.
 Default is `[]`.
 
+- **[`issue_labels_merge_with_github_labels`](#issue_label-object-attributes)**: *(Optional `bool`)*
+Specify if github default labels will be handled by terraform. This should be decided on upon creation of the repository. If you later decide to disable this feature, github default labels will be destroyed if not
+replaced by labels set in `issue_labels` argument.
+Default is `true`.
+
 ##### Projects Configuration
 - **[`projects`](#project-object-attributes)**: *(Optional `list(project)`)*
 This resource allows you to create and manage projects for GitHub repository.
@@ -256,7 +261,8 @@ The following top-level arguments can be set as defaults:
 `gitignore_template`,
 `license_template`,
 `default_branch`,
-`topics`.
+`topics`,
+`issue_labels_merge_with_github_labels`.
 Module defaults are used for all arguments that are not set in `defaults`.
 Using top level arguments override defaults set by this argument.
 Default is `{}`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ module "repository" {
   version = "0.0.8"
 
   name               = "terraform-github-repository"
-  allow_merge_commit = true
   license_template   = "apache-2.0"
   gitignore_template = "Terraform"
 }
@@ -78,21 +77,17 @@ for details and use-cases.
 The name of the repository.
 
 - **`allow_merge_commit`**: *(Optional `bool`)*
-Set to `true` to enable merge commits on the repository.
-At least one of `allow_merge_commit`, `allow_squash_merge` or `allow_rebase_merge`
-has to be set to `true`.
-Default is `false`.
+Set to `false` to disable merge commits on the repository.
+If you set this to `false` you have to enable either `allow_squash_merge`
+or `allow_rebase_merge`.
+Default is `true`.
 
 - **`allow_squash_merge`**: *(Optional `bool`)*
 Set to `true` to enable squash merges on the repository.
-At least one of `allow_merge_commit`, `allow_squash_merge` or `allow_rebase_merge`
-has to be set to `true`.
 Default is `false`.
 
 - **`allow_rebase_merge`**: *(Optional `bool`)*
 Set to `true` to enable rebase merges on the repository.
-At least one of `allow_merge_commit`, `allow_squash_merge` or `allow_rebase_merge`
-has to be set to `true`.
 Default is `false`.
 
 - **`description`**: *(Optional `string`)*

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ features like Branch Protection or Collaborator Management.
   Merge Strategy,
   Auto Init,
   License Template,
-  Gitignore Template
+  Gitignore Template,
+  Template Repository
 
 - **Extended S3 Features**:
   Branch Protection,
@@ -47,6 +48,7 @@ features like Branch Protection or Collaborator Management.
   Projects
 
 - *Features not yet implemented*:
+  Repository Webhooks,
   Project Columns support
 
 ## Getting Started
@@ -196,13 +198,15 @@ representation with the `key` argument being set to the `string`.
 Default is `[]`.
 
 - **[`deploy_keys_computed`](#deploy_keys-object-attributes)**: *(Optional `list(object|string)`)*
+Same as `deploy_keys` argument with the following differences:
 Use this argument if you depend on computed keys that terraform can not use in
 resource `for_each` execution. Downside of this is the recreation of deploy key
-resources whenever the order in the list changes. Prefer `deploy_keys` whenever possible.
-This argument does **not** conflict with `deploy_keys` and can be used only for computed resources.
+resources whenever the order in the list changes. **Prefer `deploy_keys` whenever possible.**
+This argument does **not** conflict with `deploy_keys` and should exclusively be
+used for computed resources.
 Default is `[]`.
 
-#### [`template`](#repository-configuration) Object Attributes
+#### [`template`](#repository-creation-configuration) Object Attributes
 - **`owner`**: ***(Required `string`)***
 The GitHub organization or user the template repository is owned by.
 
@@ -219,7 +223,7 @@ Default is the comment field of SSH public key if it is not empty else it defaul
 `md5(key)`.
 
 - **`read_only`**: *(Optional `bool`)*
-Specifies teh level of access for the key.
+Specifies the level of access for the key.
 Default is `true`.
 
 - *`id`*: *(Optional `string`)*

--- a/examples/private-repository-with-team/main.tf
+++ b/examples/private-repository-with-team/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "github" {
-  version = "~> 2.3"
+  version = ">= 2.3.1, < 3.0.0"
 }
 
 module "repository" {

--- a/examples/private-repository-with-team/main.tf
+++ b/examples/private-repository-with-team/main.tf
@@ -30,7 +30,7 @@ module "repository" {
     github_team.team.id
   ]
 
-  branch_protection_rules = [
+  branch_protections = [
     {
       branch                 = "master"
       enforce_admins         = true

--- a/examples/public-repository-complete-example/main.tf
+++ b/examples/public-repository-complete-example/main.tf
@@ -115,11 +115,7 @@ module "repository" {
       key       = tls_private_key.deploy[0].public_key_openssh
       read_only = true
     },
-    {
-      title     = "Test Key"
-      key       = tls_private_key.deploy[1].public_key_openssh
-      read_only = false
-    }
+    tls_private_key.deploy[1].public_key_openssh
   ]
 
   projects = [

--- a/examples/public-repository-complete-example/main.tf
+++ b/examples/public-repository-complete-example/main.tf
@@ -70,7 +70,7 @@ module "repository" {
     github_team.team.id
   ]
 
-  branch_protection_rules = [
+  branch_protections = [
     {
       branch                 = "master"
       enforce_admins         = true

--- a/examples/public-repository-complete-example/main.tf
+++ b/examples/public-repository-complete-example/main.tf
@@ -12,7 +12,7 @@ terraform {
 # -----------------------------------------------------------------------------
 provider "github" {
   # we want to be compatible with 2.x series of github provider
-  version = "~> 2.3"
+  version = ">= 2.3.1, < 3.0.0"
   # credentials are read from the environment
   # GITHUB_TOKEN
   # GITHUB_ORGANIZATION

--- a/examples/public-repository-with-collaborators/main.tf
+++ b/examples/public-repository-with-collaborators/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "github" {
-  version = "~> 2.3"
+  version = ">= 2.3.1, < 3.0.0"
 }
 
 provider "random" {

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "github" {
-  version = "~> 2.3"
+  version = ">= 2.3.1, < 3.0.0"
 }
 
 provider "random" {

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   has_issues         = var.has_issues == null ? lookup(var.defaults, "has_issues", false) : var.has_issues
   has_projects       = var.has_projects == null ? lookup(var.defaults, "has_projects", false) : length(var.projects) > 0 ? true : var.has_projects
   has_wiki           = var.has_wiki == null ? lookup(var.defaults, "has_wiki", false) : var.has_wiki
-  allow_merge_commit = var.allow_merge_commit == null ? lookup(var.defaults, "allow_merge_commit", false) : var.allow_merge_commit
+  allow_merge_commit = var.allow_merge_commit == null ? lookup(var.defaults, "allow_merge_commit", true) : var.allow_merge_commit
   allow_rebase_merge = var.allow_rebase_merge == null ? lookup(var.defaults, "allow_rebase_merge", false) : var.allow_rebase_merge
   allow_squash_merge = var.allow_squash_merge == null ? lookup(var.defaults, "allow_squash_merge", false) : var.allow_squash_merge
   has_downloads      = var.has_downloads == null ? lookup(var.defaults, "has_downloads", false) : var.has_downloads

--- a/main.tf
+++ b/main.tf
@@ -197,8 +197,12 @@ resource "github_team_repository" "team_repository" {
 # Repository deploy keys
 #
 locals {
+  deploy_keys_computed_temp = [
+    for d in var.deploy_keys_computed : try({ key = tostring(d) }, d)
+  ]
+
   deploy_keys_computed = [
-    for d in var.deploy_keys_computed : merge({
+    for d in local.deploy_keys_computed_temp : merge({
       title     = length(split(" ", d.key)) > 2 ? element(split(" ", d.key), 2) : md5(d.key)
       read_only = true
     }, d)
@@ -215,8 +219,12 @@ resource "github_repository_deploy_key" "deploy_key_computed" {
 }
 
 locals {
+  deploy_keys_temp = [
+    for d in var.deploy_keys : try({ key = tostring(d) }, d)
+  ]
+
   deploy_keys = {
-    for d in var.deploy_keys : lookup(d, "id", md5(d.key)) => merge({
+    for d in local.deploy_keys_temp : lookup(d, "id", md5(d.key)) => merge({
       title     = length(split(" ", d.key)) > 2 ? element(split(" ", d.key), 2) : md5(d.key)
       read_only = true
     }, d)

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ locals {
   default_branch     = var.default_branch == null ? lookup(var.defaults, "default_branch", "") : var.default_branch
   standard_topics    = var.topics == null ? lookup(var.defaults, "topics", []) : var.topics
   topics             = concat(local.standard_topics, var.extra_topics)
+  template           = var.template == null ? [] : [var.template]
 }
 
 locals {
@@ -78,11 +79,21 @@ resource "github_repository" "repository" {
   archived           = var.archived
   topics             = local.topics
 
+  dynamic "template" {
+    for_each = local.template
+
+    content {
+      owner      = template.value.owner
+      repository = template.value.repository
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       auto_init,
       license_template,
       gitignore_template,
+      template,
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -170,11 +170,19 @@ resource "github_issue_label" "label" {
 # Repository collaborators
 #
 locals {
-  collab_admin = { for i in var.admin_collaborators : i => "admin" }
-  collab_push  = { for i in var.push_collaborators : i => "push" }
-  collab_pull  = { for i in var.pull_collaborators : i => "pull" }
+  collab_admin    = { for i in var.admin_collaborators : i => "admin" }
+  collab_push     = { for i in var.push_collaborators : i => "push" }
+  collab_pull     = { for i in var.pull_collaborators : i => "pull" }
+  collab_triage   = { for i in var.triage_collaborators : i => "triage" }
+  collab_maintain = { for i in var.maintain_collaborators : i => "maintain" }
 
-  collaborators = merge(local.collab_admin, local.collab_push, local.collab_pull)
+  collaborators = merge(
+    local.collab_admin,
+    local.collab_push,
+    local.collab_pull,
+    local.collab_triage,
+    local.collab_maintain,
+  )
 }
 
 resource "github_repository_collaborator" "collaborator" {

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 
 locals {
   branch_protections = [
-    for b in concat(var.branch_protections, var.branch_protection_rules) : merge({
+    for b in var.branch_protections : merge({
       branch                        = null
       enforce_admins                = null
       require_signed_commits        = null

--- a/main.tf
+++ b/main.tf
@@ -197,11 +197,19 @@ resource "github_repository_collaborator" "collaborator" {
 # Repository teams
 #
 locals {
-  team_admin = [for i in var.admin_team_ids : { team_id = i, permission = "admin" }]
-  team_push  = [for i in var.push_team_ids : { team_id = i, permission = "push" }]
-  team_pull  = [for i in var.pull_team_ids : { team_id = i, permission = "pull" }]
+  team_admin    = [for i in var.admin_team_ids : { team_id = i, permission = "admin" }]
+  team_push     = [for i in var.push_team_ids : { team_id = i, permission = "push" }]
+  team_pull     = [for i in var.pull_team_ids : { team_id = i, permission = "pull" }]
+  team_triage   = [for i in var.triage_team_ids : { team_id = i, permission = "triage" }]
+  team_maintain = [for i in var.maintain_team_ids : { team_id = i, permission = "maintain" }]
 
-  teams = concat(local.team_admin, local.team_push, local.team_pull)
+  teams = concat(
+    local.team_admin,
+    local.team_push,
+    local.team_pull,
+    local.team_triage,
+    local.team_maintain,
+  )
 }
 
 resource "github_team_repository" "team_repository" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,22 +30,22 @@ output "git_clone_url" {
 
 output "collaborators" {
   value       = github_repository_collaborator.collaborator
-  description = ""
+  description = "A map of collaborator objects keyed by collaborator.name."
 }
 
 output "projects" {
   value       = github_repository_project.repository_project
-  description = ""
+  description = "A map of projects keyed by project input id."
 }
 
 locals {
   deploy_keys_output = merge({
     for i, d in github_repository_deploy_key.deploy_key_computed :
-    lookup(var.deploy_keys_computed[i], "id", md5(d.key)) => d
+    lookup(local.deploy_keys_computed_temp[i], "id", md5(d.key)) => d
   }, github_repository_deploy_key.deploy_key)
 }
 
 output "deploy_keys" {
   value       = local.deploy_keys_output
-  description = ""
+  description = "A map of deploy keys keyed by input id."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,6 +38,11 @@ output "projects" {
   description = "A map of projects keyed by project input id."
 }
 
+output "issue_labels" {
+  value       = github_issue_label.label
+  description = "A map of issue labels keyed by label input id or name."
+}
+
 locals {
   deploy_keys_output = merge({
     for i, d in github_repository_deploy_key.deploy_key_computed :

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,15 @@ variable "extra_topics" {
   default     = []
 }
 
+variable "template" {
+  type = object({
+    owner      = string
+    repository = string
+  })
+  description = "Template repository to use. (Default: {})"
+  default     = null
+}
+
 variable "admin_collaborators" {
   type        = list(string)
   description = "A list of users to add as collaborators granting them admin (full) permission."

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "has_wiki" {
 
 variable "allow_merge_commit" {
   type        = bool
-  description = "Set to true to enable merge commits on the repository. (Default: false)"
+  description = "Set to false to disable merge commits on the repository. (Default: true)"
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -256,6 +256,12 @@ variable "branch_protections" {
   # ]
 }
 
+variable "issue_labels_merge_with_github_labels" {
+  type        = bool
+  description = "Specify if you want to merge and control githubs default set of issue labels."
+  default     = null
+}
+
 variable "issue_labels" {
   type = list(object({
     name        = string

--- a/variables.tf
+++ b/variables.tf
@@ -198,12 +198,6 @@ variable "maintain_team_ids" {
   default     = []
 }
 
-variable "branch_protection_rules" {
-  type        = any
-  description = "(DEPRECATED) Use variable branch_protections instead."
-  default     = []
-}
-
 variable "branch_protections" {
   type = any
 

--- a/variables.tf
+++ b/variables.tf
@@ -248,7 +248,7 @@ variable "issue_labels" {
 }
 
 variable "deploy_keys" {
-  type        = list(any)
+  type        = any
   description = "Configure a deploy key ( SSH key ) that grants access to a single GitHub repository. This key is attached directly to the repository instead of to a personal user account."
   default     = []
 
@@ -268,7 +268,7 @@ variable "deploy_keys" {
 }
 
 variable "deploy_keys_computed" {
-  type        = list(any)
+  type        = any
   description = "Configure a deploy key ( SSH key ) that grants access to a single GitHub repository. This key is attached directly to the repository instead of to a personal user account."
   default     = []
 

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "pull_team_ids" {
 }
 
 variable "branch_protection_rules" {
+  type        = any
+  description = "(DEPRECATED) Use variable branch_protections instead."
+  default     = []
+}
+
+variable "branch_protections" {
   type = any
 
   # We can't use a detailed type specification due to a terraform limitation. However, this might be changed in a future
@@ -196,7 +202,7 @@ variable "branch_protection_rules" {
   default     = []
 
   # Example:
-  # branch_protection_rules = [
+  # branch_protections = [
   #   {
   #     branch                 = "master"
   #     enforce_admins         = true

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,18 @@ variable "pull_collaborators" {
   default     = []
 }
 
+variable "triage_collaborators" {
+  type        = list(string)
+  description = "A list of users to add as collaborators granting them triage permission."
+  default     = []
+}
+
+variable "maintain_collaborators" {
+  type        = list(string)
+  description = "A list of users to add as collaborators granting them maintain permission."
+  default     = []
+}
+
 variable "admin_team_ids" {
   type        = list(string)
   description = "A list of teams (by id) to grant admin (full) permission to."

--- a/variables.tf
+++ b/variables.tf
@@ -186,6 +186,18 @@ variable "pull_team_ids" {
   default     = []
 }
 
+variable "triage_team_ids" {
+  type        = list(string)
+  description = "A list of teams (by id) to grant triage permission to."
+  default     = []
+}
+
+variable "maintain_team_ids" {
+  type        = list(string)
+  description = "A list of teams (by id) to grant maintain permission to."
+  default     = []
+}
+
 variable "branch_protection_rules" {
   type        = any
   description = "(DEPRECATED) Use variable branch_protections instead."

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.9"
 
   required_providers {
-    github = "~> 2.3"
+    github = ">= 2.3.1, < 3.0.0"
   }
 }


### PR DESCRIPTION
# Notes
### Breaking changes:
- renamed `branch_protection_rules` to `branch_protections` to match native provider resource naming
- changed the default for `allow_merge_commits` to `true` so you do not have to specify any merge strategy. This seems to be the widely accepted merge strategy in open source projects. So it makes sense to use it as a default.
- `issue_labels_merge_with_github_labels` defaults to `true` and handles githubs default labels via terraform.

# Enhancements
- allow to pass `deploy_keys` as `string` or `object`
- add `issue_labels` map as output

# New Features
- add support for `template` repositories (added in github provider 2.3.0)
- add support for `triage` and `maintain` collaborators (added in github provider 2.3.1)
- add support for `triage` and `maintain` teams (added in github provider 2.3.1)
- add support for handling github default issues.

# Bug Fixes
- some more additions to `README.md` (still not complete)