### PR TITLE
set default value of var.allow_merge_commit to true

### DIFF
--- a/examples/public-repository-complete-example/main.tf
+++ b/examples/public-repository-complete-example/main.tf
@@ -11,9 +11,10 @@ terraform {
 # We are using specific version of different providers for consistant results
 # -----------------------------------------------------------------------------
 provider "github" {
-  # we want to be compatible with 2.x series of github provider
+  # We want to be compatible with 2.x series of github provider
   version = ">= 2.3.1, < 3.0.0"
-  # credentials are read from the environment
+
+  # Credentials are read from the environment
   # GITHUB_TOKEN
   # GITHUB_ORGANIZATION
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,6 @@ locals {
   has_issues         = var.has_issues == null ? lookup(var.defaults, "has_issues", false) : var.has_issues
   has_projects       = var.has_projects == null ? lookup(var.defaults, "has_projects", false) : length(var.projects) > 0 ? true : var.has_projects
   has_wiki           = var.has_wiki == null ? lookup(var.defaults, "has_wiki", false) : var.has_wiki
-  allow_merge_commit = var.allow_merge_commit == null ? lookup(var.defaults, "allow_merge_commit", true) : var.allow_merge_commit
   allow_rebase_merge = var.allow_rebase_merge == null ? lookup(var.defaults, "allow_rebase_merge", false) : var.allow_rebase_merge
   allow_squash_merge = var.allow_squash_merge == null ? lookup(var.defaults, "allow_squash_merge", false) : var.allow_squash_merge
   has_downloads      = var.has_downloads == null ? lookup(var.defaults, "has_downloads", false) : var.has_downloads
@@ -74,7 +73,7 @@ resource "github_repository" "repository" {
   has_issues         = local.has_issues
   has_projects       = local.has_projects
   has_wiki           = local.has_wiki
-  allow_merge_commit = local.allow_merge_commit
+  allow_merge_commit = var.allow_merge_commit
   allow_rebase_merge = local.allow_rebase_merge
   allow_squash_merge = local.allow_squash_merge
   has_downloads      = local.has_downloads

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "has_wiki" {
 variable "allow_merge_commit" {
   type        = bool
   description = "Set to false to disable merge commits on the repository. (Default: true)"
-  default     = null
+  default     = true
 }
 
 variable "allow_squash_merge" {


### PR DESCRIPTION
`var.allow_merge_commit` should be set to `true`.

At the moment the default values of `var.allow_merge_commit`, `var.allow_rebase_merge`, and  `allow_squash_merge` are all set to `false`. We need to at least set one of the options to `true` in order to create the repository.

We should set the most used option `var.allow_merge_commit` to `true` so we can create a new repository as easy as:

```
module "repository" {
  source  = "mineiros-io/repository/github"
  version = "0.0.7"

  name = "test-repository"
}
```