### PR TITLE
use team slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,41 @@ Default is `""`
 Use a template repository to create this resource.
 See [Template Object Attributes](#template-object-attributes) below for details.
 
+##### Teams Configuration
+Teams need to exist beforehand. Your can use non-computed
+(known at `terraform plan`) team names or slugs
+(`*_teams` Attributes; **recommended**)
+or computed (only known in `terraform apply` phase) team IDs
+(`*_team_ids` Attributes).
+
+- **`pull_teams`** or **`pull_team_ids`**: *(Optional `list(string)`)*
+A list of teams to grant pull (read-only) permission.
+Recommended for non-code contributors who want to view or discuss your project.
+Default is `[]`.
+
+- **`triage_teams`** or **`triage_team_ids`**: *(Optional `list(string)`)*
+A list of teams to grant triage permission.
+Recommended for contributors who need to proactively manage issues and pull requests
+without write access.
+Default is `[]`.
+
+- **`push_teams`** or **`push_team_ids`**: *(Optional `list(string)`)*
+A list of teams to grant push (read-write) permission.
+Recommended for contributors who actively push to your project.
+Default is `[]`.
+
+- **`maintain_teams`** or **`maintain_team_ids`**: *(Optional `list(string)`)*
+A list of teams to grant maintain permission.
+Recommended for project managers who need to manage the repository without access
+to sensitive or destructive actions.
+Default is `[]`.
+
+- **`admin_teams`** or **`admin_team_ids`**: *(Optional `list(string)`)*
+A list of teams to grant admin (full) permission.
+Recommended for people who need full access to the project, including sensitive
+and destructive actions like managing security or deleting a repository.
+Default is `[]`.
+
 ##### Collaborator Configuration
 - **`pull_collaborators`**: *(Optional `list(string)`)*
 A list of user names to add as collaborators granting them pull (read-only) permission.

--- a/examples/private-repository-with-team/main.tf
+++ b/examples/private-repository-with-team/main.tf
@@ -38,8 +38,8 @@ module "repository" {
   archived           = false
   topics             = ["terraform", "integration-test"]
 
-  admin_team_ids = [
-    github_team.team.id
+  admin_teams = [
+    var.team_name
   ]
 
   branch_protections = [

--- a/examples/public-repository-complete-example/main.tf
+++ b/examples/public-repository-complete-example/main.tf
@@ -68,8 +68,8 @@ module "repository" {
   archived           = false
   topics             = var.topics
 
-  admin_team_ids = [
-    github_team.team.id
+  admin_teams = [
+    var.team_name
   ]
 
   branch_protections = [

--- a/main.tf
+++ b/main.tf
@@ -270,31 +270,31 @@ resource "github_repository_collaborator" "collaborator" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
-# Teams
+# Teams by id
 # ---------------------------------------------------------------------------------------------------------------------
 
 locals {
-  team_admin    = [for i in var.admin_team_ids : { team_id = i, permission = "admin" }]
-  team_push     = [for i in var.push_team_ids : { team_id = i, permission = "push" }]
-  team_pull     = [for i in var.pull_team_ids : { team_id = i, permission = "pull" }]
-  team_triage   = [for i in var.triage_team_ids : { team_id = i, permission = "triage" }]
-  team_maintain = [for i in var.maintain_team_ids : { team_id = i, permission = "maintain" }]
+  team_id_admin    = [for i in var.admin_team_ids : { team_id = i, permission = "admin" }]
+  team_id_push     = [for i in var.push_team_ids : { team_id = i, permission = "push" }]
+  team_id_pull     = [for i in var.pull_team_ids : { team_id = i, permission = "pull" }]
+  team_id_triage   = [for i in var.triage_team_ids : { team_id = i, permission = "triage" }]
+  team_id_maintain = [for i in var.maintain_team_ids : { team_id = i, permission = "maintain" }]
 
-  teams = concat(
-    local.team_admin,
-    local.team_push,
-    local.team_pull,
-    local.team_triage,
-    local.team_maintain,
+  team_ids = concat(
+    local.team_id_admin,
+    local.team_id_push,
+    local.team_id_pull,
+    local.team_id_triage,
+    local.team_id_maintain,
   )
 }
 
 resource "github_team_repository" "team_repository" {
-  count = length(local.teams)
+  count = length(local.team_ids)
 
   repository = github_repository.repository.name
-  team_id    = local.teams[count.index].team_id
-  permission = local.teams[count.index].permission
+  team_id    = local.team_ids[count.index].team_id
+  permission = local.team_ids[count.index].permission
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,36 @@ variable "maintain_team_ids" {
   default     = []
 }
 
+variable "admin_teams" {
+  description = "A list of teams (by name/slug) to grant admin (full) permission to."
+  type        = list(string)
+  default     = []
+}
+
+variable "push_teams" {
+  description = "A list of teams (by name/slug) to grant push (read-write) permission to."
+  type        = list(string)
+  default     = []
+}
+
+variable "pull_teams" {
+  description = "A list of teams (by name/slug) to grant pull (read-only) permission to."
+  type        = list(string)
+  default     = []
+}
+
+variable "triage_teams" {
+  description = "A list of teams (by name/slug) to grant triage permission to."
+  type        = list(string)
+  default     = []
+}
+
+variable "maintain_teams" {
+  description = "A list of teams (by name/slug) to grant maintain permission to."
+  type        = list(string)
+  default     = []
+}
+
 variable "branch_protections" {
   description = "Configuring protected branches. For details please check: https://www.terraform.io/docs/providers/github/r/branch_protection.html"
   type        = any


### PR DESCRIPTION
# Enhancements
- Allow adding teams to repository by their name or slug (this uses very basic slug calculation and might need further improvement in the future)
- non breaking changes

# how implemented
- convert team name to slug: `lowercase()` and `replace(..., "/[^a-z0-9]", "-")`
- use `data` source to load `team_id`s from `slug` input
- apply dependencies to defer loading `team_id`s
