### PR TITLE
Add issue_labels_create argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ Specify if github default labels will be handled by terraform. This should be de
 replaced by labels set in `issue_labels` argument.
 Default is `true`.
 
+- **[`issue_labels_create`](#issue_label-object-attributes)**: *(Optional `bool`)*
+Specify whether you want to force or suppress the creation of issues labels.
+Default is `true` if `has_issues` is `true` or `issue_labels` is non-empty, otherwise default is `false`.
+
 ##### Projects Configuration
 - **[`projects`](#project-object-attributes)**: *(Optional `list(project)`)*
 This resource allows you to create and manage projects for GitHub repository.
@@ -326,6 +330,7 @@ The following top-level arguments can be set as defaults:
 `license_template`,
 `default_branch`,
 `topics`,
+`issue_labels_create`,
 `issue_labels_merge_with_github_labels`.
 Module defaults are used for all arguments that are not set in `defaults`.
 Using top level arguments override defaults set by this argument.

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,9 @@ locals {
   standard_topics        = var.topics == null ? lookup(var.defaults, "topics", []) : var.topics
   topics                 = concat(local.standard_topics, var.extra_topics)
   template               = var.template == null ? [] : [var.template]
+  issue_labels_create    = var.issue_labels_create == null ? lookup(var.defaults, "issue_labels_create", local.issue_labels_create_computed) : var.issue_labels_create
+
+  issue_labels_create_computed = local.has_issues || length(var.issue_labels) > 0
 
   # for readability
   var_gh_labels = var.issue_labels_merge_with_github_labels
@@ -240,7 +243,7 @@ locals {
 }
 
 resource "github_issue_label" "label" {
-  for_each = local.issue_labels
+  for_each = local.issue_labels_create ? local.issue_labels : {}
 
   repository  = github_repository.repository.name
   name        = each.value.name

--- a/variables.tf
+++ b/variables.tf
@@ -324,6 +324,12 @@ variable "issue_labels_merge_with_github_labels" {
   default     = null
 }
 
+variable "issue_labels_create" {
+  description = "Specify whether you want to force or suppress the creation of issues labels."
+  type        = bool
+  default     = null
+}
+
 variable "issue_labels" {
   description = "Configure a GitHub issue label resource."
   type = list(object({


### PR DESCRIPTION
# Problem statement
When disabling issues via `has_issues = false` the module will still import Github issue labels. which creates a bunch of unneeded resources.

# Implemented solution
This changes the default of this behavior to only create/import issues when issues are enabled or issue labels are specified.
A new argument `issue_labels_create` was added to disable issue label creation completely or to force creating issue labels even if `has_issues == false`


# Breaking Change
This could be considered a breaking change as it might delete issue_labels that have been imported before. 
You could prevent this by actively setting `issue_labels_create = true`.
