### PR TITLE
Fix dependency issue when assigning teams by name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -332,7 +332,10 @@ data "github_team" "teams" {
 
   slug = each.value.slug
 
-  depends_on = [github_repository.repository]
+  depends_on = [
+    var.module_depends_on,
+    github_repository.repository,
+  ]
 }
 
 resource "github_team_repository" "team_repository_by_slug" {


### PR DESCRIPTION
Fix the dependency when creating a team and assigning it in the same run by its team name to the repository.
