### PR TITLE
Revert "Fix dependency issue when assigning teams by name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ Use a template repository to create this resource.
 See [Template Object Attributes](#template-object-attributes) below for details.
 
 ##### Teams Configuration
-Teams need to exist beforehand. Your can use non-computed
+Your can use non-computed
 (known at `terraform plan`) team names or slugs
-(`*_teams` Attributes; **recommended**)
+(`*_teams` Attributes)
 or computed (only known in `terraform apply` phase) team IDs
 (`*_team_ids` Attributes).
-When using non-computed names/slugs make sure to add the actual team resources as
-indirect dependencies in `module_depends_on` as explained in
-[Module Configuration](#module-configuration) above.
+**When using non-computed names/slugs teams need to exist before running plan.**
+This is due to some terraform limitation and we will update the module once terraform
+removed thislimitation.
 
 - **`pull_teams`** or **`pull_team_ids`**: *(Optional `list(string)`)*
 A list of teams to grant pull (read-only) permission.

--- a/examples/private-repository-with-team/main.tf
+++ b/examples/private-repository-with-team/main.tf
@@ -36,8 +36,8 @@ module "repository" {
   archived           = false
   topics             = ["terraform", "integration-test"]
 
-  admin_teams = [
-    var.team_name
+  admin_team_ids = [
+    github_team.team.id
   ]
 
   branch_protections = [

--- a/examples/public-repository-complete-example/main.tf
+++ b/examples/public-repository-complete-example/main.tf
@@ -60,8 +60,8 @@ module "repository" {
   archived               = false
   topics                 = var.topics
 
-  admin_teams = [
-    var.team_name
+  admin_team_ids = [
+    github_team.team.id
   ]
 
   branch_protections = [

--- a/main.tf
+++ b/main.tf
@@ -332,10 +332,7 @@ data "github_team" "teams" {
 
   slug = each.value.slug
 
-  depends_on = [
-    var.module_depends_on,
-    github_repository.repository,
-  ]
+  depends_on = [github_repository.repository]
 }
 
 resource "github_team_repository" "team_repository_by_slug" {

--- a/main.tf
+++ b/main.tf
@@ -331,8 +331,6 @@ data "github_team" "teams" {
   for_each = local.teams
 
   slug = each.value.slug
-
-  depends_on = [github_repository.repository]
 }
 
 resource "github_team_repository" "team_repository_by_slug" {


### PR DESCRIPTION
Reverts mineiros-io/terraform-github-repository#36

this fix will always show a plan and recreate resources... need to reimplement differently...

# breaking change
- this is a breaking change of a non-usable feature. I will try to figure out some cool hack to make it happen anyway but in the meantime make it an explicit  execption to first create teams and then assign them to repositories..
