### PR TITLE
Fix failing terraform validate in pre-commit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ default: help
 
 ## Run pre-commit hooks in build-tools docker container.
 .PHONY: test/pre-commit
+test/pre-commit: DOCKER_FLAGS += ${DOCKER_GITHUB_FLAGS}
 test/pre-commit:
 	$(call docker-run,pre-commit run -a)
 


### PR DESCRIPTION
This commit fixes a failure in terraform validate as it requires
the GITHUB_TOKEN to be present as of (at least) version 2.8.0.