### PR TITLE
Add support for Terraform v1.0.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12.20, < 0.16"
+  required_version = ">= 0.12.20, < 2.0.0"
 
   # 4.7.0 to 4.9.1 has a security regression: new repositories created via a  
   # template have a public visibility. Has been fixed in 4.9.2.


### PR DESCRIPTION
Terraform 1.0.0 is an extension of 0.15.5, and this module is compatible with this version.