### PR TITLE
feat: use official GitHub provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,6 +8,9 @@ terraform {
   # 4.7.0 to 4.9.1 has a security regression: new repositories created via a  
   # template have a public visibility. Has been fixed in 4.9.2.
   required_providers {
-    github = ">= 4.5, < 5.0, != 4.7.0, != 4.8.0, != 4.9.0, != 4.9.1"
+    github = {
+      source  = "integrations/github"
+      version = ">= 4.5, < 5.0, != 4.7.0, != 4.8.0, != 4.9.0, != 4.9.1"
+    }
   }
 }


### PR DESCRIPTION
With this configuration:

```hcl
terraform {
  required_providers {
    github = {
      source  = "integrations/github"
      version = "4.10.1"
    }
  }

  required_version = "0.15.3"
}

module "this" {
  for_each = local.repos

  source  = "mineiros-io/repository/github"
  version = "~> 0.10.1"

  providers = {
    github = github,
  }

  ...
}
```

When initializing, we get the following issue:

```bash
$ terraform init
Initializing modules...
Downloading mineiros-io/repository/github 0.10.1 for this...
- this in .terraform/modules/this
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Invalid type for provider module.this.provider["registry.terraform.io/hashicorp/github"]
│ 
│   on main.tf line 20, in module "this":
│   20:     github = github,
│ 
│ Cannot use configuration from provider["registry.terraform.io/integrations/github"] for module.this.provider["registry.terraform.io/hashicorp/github"]. The given provider configuration is for a different provider type.
```

After changing to the configuration below, `init` works fine:

```hcl
module "this" {
  for_each = local.repos

  source = "git::https://github.com/allianz-direct/terraform-github-repository.git?ref=feature/use-official-github-provider"

  providers = {
    github = github,
  }

  ...
}
```