### PR TITLE
Fixes 1.0 Error

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -57,6 +57,7 @@ output "deploy_keys" {
 
 output "webhooks" {
   value       = github_repository_webhook.repository_webhook
+  sensitive   = true
   description = "All attributes and arguments as returned by the github_repository_webhook resource."
 }
 


### PR DESCRIPTION
Got this error from working with Terraform 1.05

│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true