### PR TITLE
Add GitHub Autolink References configuration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _Security related notice: Versions 4.7.0, 4.8.0, 4.9.0 and 4.9.1 of the Terrafor
     - [Projects Configuration](#projects-configuration)
     - [Webhooks Configuration](#webhooks-configuration)
     - [Secrets Configuration](#secrets-configuration)
+    - [Autolink References](#autolink-references-configuration)
   - [Module Configuration](#module-configuration)
 - [Module Outputs](#module-outputs)
 - [External Documentation](#external-documentation)
@@ -830,6 +831,24 @@ This is due to some terraform limitation and we will update the module once terr
   If this is specified it must be a number between 1-6.
   This requirement matches Github's API, see the upstream documentation for more information.
   Default is no approving reviews are required.
+
+#### Autolink References Configuration
+
+- [**`autolink_references`**](#var-autolink-references): *(Optional `list(autolink_references)`)*<a name="var-autolink-references"></a>
+
+  This resource allows you to create and manage autolink references for GitHub repository. 
+
+  Default is `[]`.
+
+  Each `autolink_reference` object in the list accepts the following attributes:
+
+  - [**`key_prefix`**](#attr-autolink-references-key_prefix): *(**Required** `string`)*<a name="attr-autolink-references-key_prefix"></a>
+
+    The prefix of the autolink reference.
+
+  - [**`target_url_template`**](#attr-autolink-references-target_url_template): *(**Required** `string`)*<a name="attr-autolink-references-target_url_template"></a>
+
+    The target url template of the autolink reference.
 
 ### Module Configuration
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -1084,6 +1084,34 @@ section {
     }
 
     section {
+      title = "Autolink References Configuration"
+
+      variable "autolink_references" {
+        type        = list(autolink_reference)
+        default     = []
+        description = <<-END
+            This resource allows you to create and manage autolink references for GitHub repository.
+          END
+
+        attribute "key_prefix" {
+          required    = true
+          type        = string
+          description = <<-END
+              The key prefix of the autolink reference.
+            END
+        }
+
+        attribute "target_url_template" {
+          type        = string
+          default     = ""
+          description = <<-END
+              The target url template of the autolink reference.
+            END
+        }
+      }
+    }
+
+    section {
       title = "Module Configuration"
 
       variable "module_depends_on" {
@@ -1209,6 +1237,7 @@ section {
         - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborator
         - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key
         - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_project
+        - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_autolink_reference
       END
     }
   }
@@ -1300,6 +1329,9 @@ references {
   }
   ref "`github_repository_project`" {
     value = "https://www.terraform.io/docs/providers/github/r/repository_project.html#attributes-reference"
+  }
+  ref "`github_repository_autolink_reference`" {
+    value = "https://www.terraform.io/docs/providers/github/r/repository_autolink_reference.html#attributes-reference"
   }
   ref "homepage" {
     value = "https://mineiros.io/?ref=terraform-github-repository"

--- a/main.tf
+++ b/main.tf
@@ -467,3 +467,21 @@ resource "github_actions_secret" "repository_secret" {
   secret_name     = each.key
   plaintext_value = each.value
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Autolink References
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  autolink_references = { for i in var.autolink_references : lookup(i, "id", lower(i.key_prefix)) => merge({
+    target_url_template = null
+  }, i) }
+}
+
+resource "github_repository_autolink_reference" "repository_autolink_reference" {
+  for_each = local.autolink_references
+
+  repository          = github_repository.repository.name
+  key_prefix          = each.value.key_prefix
+  target_url_template = each.value.target_url_template
+}

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -117,6 +117,8 @@ module "repository" {
   ]
 
   projects = var.projects
+
+  autolink_references = var.autolink_references
 }
 
 resource "github_branch" "development" {

--- a/test/unit-complete/variables.tf
+++ b/test/unit-complete/variables.tf
@@ -230,3 +230,16 @@ variable "webhook_events" {
   type        = list(string)
   default     = ["issues"]
 }
+
+variable "autolink_references" {
+  description = "A list of autolink references"
+  type = list(object({
+    key_prefix          = string
+    target_url_template = string
+  }))
+
+  default = [{
+    key_prefix          = "TICKET-"
+    target_url_template = "https://hello.there/TICKET?query=<num>"
+  }]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -474,6 +474,24 @@ variable "plaintext_secrets" {
   default = {}
 }
 
+variable "autolink_references" {
+  description = "(Optional) Configuring autolink references. For details please check: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_autolink_reference"
+  type = list(object({
+    key_prefix          = string
+    target_url_template = string
+  }))
+
+  # Example:
+  # autolink_references = [
+  #   {
+  #     key_prefix          = "TICKET-"
+  #     target_url_template = "https://hello.there/TICKET?query=<num>"
+  #   }
+  # ]
+
+  default = []
+}
+
 variable "vulnerability_alerts" {
   type        = bool
   description = "(Optional) Set to `false` to disable security alerts for vulnerable dependencies. Enabling requires alerts to be enabled on the owner level."


### PR DESCRIPTION
- Implements #99  

I tried to implement the Autolink Reference Feature, but I was not able to run the tests locally. So it is a quick & dirty implementation and needs a review and probably some improvements. 

P.S.: Hey @mariux, long time no see :-) 