### PR TITLE
Add Setting require_conversation_resolution for Branch Protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,12 @@ This is due to some terraform limitation and we will update the module once terr
 
     Default is `false`.
 
+  - [**`require_conversation_resolution`**](#attr-branch_protections_v3-require_conversation_resolution): *(Optional `bool`)*<a name="attr-branch_protections_v3-require_conversation_resolution"></a>
+
+    Setting this to true requires all conversations to be resolved.
+
+    Default is `false`.
+
   - [**`require_signed_commits`**](#attr-branch_protections_v3-require_signed_commits): *(Optional `bool`)*<a name="attr-branch_protections_v3-require_signed_commits"></a>
 
     Setting this to true requires all commits to be signed with GPG.
@@ -608,6 +614,12 @@ This is due to some terraform limitation and we will update the module once terr
   - [**`enforce_admins`**](#attr-branch_protections-enforce_admins): *(Optional `bool`)*<a name="attr-branch_protections-enforce_admins"></a>
 
     Setting this to true enforces status checks for repository administrators.
+
+    Default is `false`.
+
+  - [**`require_conversation_resolution`**](#attr-branch_protections-require_conversation_resolution): *(Optional `bool`)*<a name="attr-branch_protections-require_conversation_resolution"></a>
+
+    Setting this to true requires all conversations to be resolved.
 
     Default is `false`.
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -646,6 +646,14 @@ section {
             END
           }
 
+          attribute "require_conversation_resolution" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true requires all conversations to be resolved.
+            END
+          }
+
           attribute "require_signed_commits" {
             type        = bool
             default     = false

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -49,9 +49,10 @@ module "repository" {
 
   branch_protections = [
     {
-      branch                 = "main"
-      enforce_admins         = true
-      require_signed_commits = true
+      branch                          = "main"
+      enforce_admins                  = true
+      require_conversation_resolution = true
+      require_signed_commits          = true
 
       required_status_checks = {
         strict   = true

--- a/main.tf
+++ b/main.tf
@@ -43,12 +43,13 @@ locals {
 locals {
   branch_protections = try([
     for b in local.branch_protections_v3 : merge({
-      branch                        = null
-      enforce_admins                = null
-      require_signed_commits        = null
-      required_status_checks        = {}
-      required_pull_request_reviews = {}
-      restrictions                  = {}
+      branch                          = null
+      enforce_admins                  = null
+      require_conversation_resolution = null
+      require_signed_commits          = null
+      required_status_checks          = {}
+      required_pull_request_reviews   = {}
+      restrictions                    = {}
     }, b)
   ], [])
 
@@ -171,10 +172,11 @@ resource "github_branch_protection_v3" "branch_protection" {
     github_team_repository.team_repository_by_slug
   ]
 
-  repository             = github_repository.repository.name
-  branch                 = local.branch_protections[count.index].branch
-  enforce_admins         = local.branch_protections[count.index].enforce_admins
-  require_signed_commits = local.branch_protections[count.index].require_signed_commits
+  repository                      = github_repository.repository.name
+  branch                          = local.branch_protections[count.index].branch
+  enforce_admins                  = local.branch_protections[count.index].enforce_admins
+  require_conversation_resolution = local.branch_protections[count.index].require_conversation_resolution
+  require_signed_commits          = local.branch_protections[count.index].require_signed_commits
 
   dynamic "required_status_checks" {
     for_each = local.required_status_checks[count.index]

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -76,9 +76,10 @@ module "repository" {
 
   branch_protections = [
     {
-      branch                 = "main"
-      enforce_admins         = true
-      require_signed_commits = true
+      branch                          = "main"
+      enforce_admins                  = true
+      require_conversation_resolution = true
+      require_signed_commits          = true
 
       required_status_checks = {
         strict   = true


### PR DESCRIPTION
I noticed that the property `require_conversation_resolution` in the `github_branch_protection_v3` was missing. So I added this :-)