### PR TITLE
Add support for github_branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set correct alternative type for `deploy_keys` in README
 
+### Added
+
+- Add support for `github_branches`
+
 ## [0.14.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0]
+
 ### Fixed
 
 - Set correct alternative type for `deploy_keys` in README
@@ -359,7 +361,8 @@ Please review plans and report regressions and issues asap so we can improve doc
 - This is the initial release of our GitHub Repository module with support for
   creating and managing GitHub Repositories for Organizations.
 
-[unreleased]: https://github.com/mineiros-io/terraform-github-repository/compare/v0.14.0...HEAD
+[unreleased]: https://github.com/mineiros-io/terraform-github-repository/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/mineiros-io/terraform-github-repository/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/mineiros-io/terraform-github-repository/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/mineiros-io/terraform-github-repository/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/mineiros-io/terraform-github-repository/compare/v0.11.0...v0.12.0

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ This is due to some terraform limitation and we will update the module once terr
 
   Can also be type `list(string)`. Create and manage branches within your repository.
   Additional constraints can be applied to ensure your branch is created from another branch or commit.
-  Every `string` in the list will be converted internally into the `object` representation with the `key` argument being set to the `string`. `object` details are explained below.
+  Every `string` in the list will be converted internally into the `object` representation with the `name` argument being set to the `string`. `object` details are explained below.
 
   Default is `[]`.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ _Security related notice: Versions 4.7.0, 4.8.0, 4.9.0 and 4.9.1 of the Terrafor
     - [Repository Creation Configuration](#repository-creation-configuration)
     - [Teams Configuration](#teams-configuration)
     - [Collaborator Configuration](#collaborator-configuration)
+    - [Branches Configuration](#branches-configuration)
     - [Deploy Keys Configuration](#deploy-keys-configuration)
     - [Branch Protections Configuration](#branch-protections-configuration)
     - [Issue Labels Configuration](#issue-labels-configuration)
@@ -62,6 +63,7 @@ features like Branch Protection or Collaborator Management.
   Template Repository
 
 - **Extended Repository Features**:
+  Branches,
   Branch Protection,
   Issue Labels,
   Handle Github Default Issue Labels,
@@ -259,8 +261,10 @@ See [variables.tf] and [examples/] for details and use-cases.
 - [**`default_branch`**](#var-default_branch): *(Optional `string`)*<a name="var-default_branch"></a>
 
   The name of the default branch of the repository.
-  NOTE: This can only be set after a repository has already been created, and after a correct reference has been created for the target branch inside the repository.
-  This means a user will have to omit this parameter from the initial repository creation and create the target branch inside of the repository prior to setting this attribute.
+  NOTE: The configured default branch must exist in the repository.
+  If the branch doesn't exist yet, or if you are creating a new
+  repository, please add the desired default branch to the `branches`
+  variable, which will cause Terraform to create it for you.
 
   Default is `""`.
 
@@ -415,6 +419,32 @@ This is due to some terraform limitation and we will update the module once terr
   Recommended for people who need full access to the project, including sensitive and destructive actions like managing security or deleting a repository.
 
   Default is `[]`.
+
+#### Branches Configuration
+
+- [**`branches`**](#var-branches): *(Optional `list(branch)`)*<a name="var-branches"></a>
+
+  Can also be type `list(string)`. Create and manage branches within your repository.
+  Additional constraints can be applied to ensure your branch is created from another branch or commit.
+  Every `string` in the list will be converted internally into the `object` representation with the `key` argument being set to the `string`. `object` details are explained below.
+
+  Default is `[]`.
+
+  Each `branch` object in the list accepts the following attributes:
+
+  - [**`name`**](#attr-branches-name): *(**Required** `string`)*<a name="attr-branches-name"></a>
+
+    The name of the branch to create.
+
+  - [**`source_branch`**](#attr-branches-source_branch): *(Optional `string`)*<a name="attr-branches-source_branch"></a>
+
+    The branch name to start from. Uses the configured default branch per default.
+
+  - [**`source_sha`**](#attr-branches-source_sha): *(Optional `bool`)*<a name="attr-branches-source_sha"></a>
+
+    The commit hash to start from. Defaults to the tip of `source_branch`. If provided, `source_branch` is ignored.
+
+    Default is `true`.
 
 #### Deploy Keys Configuration
 
@@ -800,6 +830,12 @@ The following attributes are exported by the module:
   resource containing all arguments as specified above and the other
   attributes as specified below.
 
+- [**`branches`**](#output-branches): *(`object(branches)`)*<a name="output-branches"></a>
+
+  All repository attributes as returned by the [`github_branch`]
+  resource containing all arguments as specified above and the other
+  attributes as specified below.
+
 - [**`full_name`**](#output-full_name): *(`string`)*<a name="output-full_name"></a>
 
   A string of the form "orgname/reponame".
@@ -856,6 +892,7 @@ The following attributes are exported by the module:
 ### Terraform Github Provider Documentation
 
 - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository
+- https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch 
 - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborator
 - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key
 - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_project

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -541,7 +541,7 @@ section {
           description = <<-END
             Can also be type `list(string)`. Create and manage branches within your repository.
             Additional constraints can be applied to ensure your branch is created from another branch or commit.
-            Every `string` in the list will be converted internally into the `object` representation with the `key` argument being set to the `string`. `object` details are explained below.
+            Every `string` in the list will be converted internally into the `object` representation with the `name` argument being set to the `string`. `object` details are explained below.
           END
 
           attribute "name" {

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -65,6 +65,7 @@ section {
         Template Repository
 
       - **Extended Repository Features**:
+        Branches,
         Branch Protection,
         Issue Labels,
         Handle Github Default Issue Labels,
@@ -317,8 +318,10 @@ section {
         default     = ""
         description = <<-END
           The name of the default branch of the repository.
-          NOTE: This can only be set after a repository has already been created, and after a correct reference has been created for the target branch inside the repository.
-          This means a user will have to omit this parameter from the initial repository creation and create the target branch inside of the repository prior to setting this attribute.
+          NOTE: The configured default branch must exist in the repository.
+          If the branch doesn't exist yet, or if you are creating a new
+          repository, please add the desired default branch to the `branches`
+          variable, which will cause Terraform to create it for you.
         END
       }
 
@@ -526,6 +529,43 @@ section {
             A list of user names to add as collaborators granting them admin (full) permission.
             Recommended for people who need full access to the project, including sensitive and destructive actions like managing security or deleting a repository.
           END
+        }
+      }
+
+      section {
+        title = "Branches Configuration"
+
+        variable "branches" {
+          type        = list(branch)
+          default     = []
+          description = <<-END
+            Can also be type `list(string)`. Create and manage branches within your repository.
+            Additional constraints can be applied to ensure your branch is created from another branch or commit.
+            Every `string` in the list will be converted internally into the `object` representation with the `key` argument being set to the `string`. `object` details are explained below.
+          END
+
+          attribute "name" {
+            required    = true
+            type        = string
+            description = <<-END
+              The name of the branch to create.
+            END
+          }
+
+          attribute "source_branch" {
+            type        = string
+            description = <<-END
+              The branch name to start from. Uses the configured default branch per default.
+            END
+          }
+
+          attribute "source_sha" {
+            type        = bool
+            default     = true
+            description = <<-END
+             The commit hash to start from. Defaults to the tip of `source_branch`. If provided, `source_branch` is ignored.
+            END
+          }
         }
       }
 
@@ -1046,6 +1086,15 @@ section {
       END
     }
 
+    output "branches" {
+      type        = object(branches)
+      description = <<-END
+        All repository attributes as returned by the [`github_branch`]
+        resource containing all arguments as specified above and the other
+        attributes as specified below.
+      END
+    }
+
     output "full_name" {
       type        = string
       description = <<-END
@@ -1138,6 +1187,7 @@ section {
       title   = "Terraform Github Provider Documentation"
       content = <<-END
         - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository
+        - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch 
         - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborator
         - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key
         - https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_project

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,6 @@
-output "repository" {
-  value       = github_repository.repository
-  description = "All attributes and arguments as returned by the github_repository resource."
-}
+# ----------------------------------------------------------------------------------------------------------------------
+# OUTPUT CALCULATED VARIABLES (prefer full objects)
+# ----------------------------------------------------------------------------------------------------------------------
 
 output "full_name" {
   value       = github_repository.repository.full_name
@@ -26,6 +25,20 @@ output "http_clone_url" {
 output "git_clone_url" {
   value       = github_repository.repository.git_clone_url
   description = "URL that can be provided to git clone to clone the repository anonymously via the git protocol."
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# OUTPUT ALL RESOURCES AS FULL OBJECTS
+# ----------------------------------------------------------------------------------------------------------------------
+
+output "repository" {
+  value       = github_repository.repository
+  description = "All attributes and arguments as returned by the github_repository resource."
+}
+
+output "branches" {
+  value       = github_branch.branch
+  description = "A map of branch objects keyed by branch name."
 }
 
 output "collaborators" {
@@ -65,3 +78,7 @@ output "secrets" {
   value       = [for secret in github_actions_secret.repository_secret : secret.secret_name]
   description = "List of secrets available."
 }
+
+# ----------------------------------------------------------------------------------------------------------------------
+# OUTPUT MODULE CONFIGURATION
+# ----------------------------------------------------------------------------------------------------------------------

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -49,8 +49,16 @@ module "repository" {
   archived               = false
   topics                 = var.topics
 
-  admin_collaborators = ["terraform-test-user-1"]
+  branches = [
+    {
+      name = "develop"
+    },
+    {
+      name = "staging"
+    },
+  ]
 
+  admin_collaborators = ["terraform-test-user-1"]
 
   admin_team_ids = [
     github_team.team.id
@@ -140,9 +148,15 @@ resource "github_branch" "development" {
 module "repository-with-defaults" {
   source = "../.."
 
-  name        = var.repository_with_defaults_name
-  description = var.repository_with_defaults_description
-  defaults    = var.repository_defaults
+  name           = var.repository_with_defaults_name
+  description    = var.repository_with_defaults_description
+  defaults       = var.repository_defaults
+  default_branch = "development"
+
+  branches = [
+    "development",
+    "prod",
+  ]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,17 @@ variable "name" {
 # These variables have defaults, but may be overridden.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "branches" {
+  description = "(Optional) A list of branches to be created in this repository."
+  type        = any
+  # type = list(object({
+  #   name          = string
+  #   source_branch = optional(string)
+  #   source_sha    = optional(string)
+  # }))
+  default = []
+}
+
 variable "defaults" {
   description = "(Optional) Overwrite defaults for various repository settings"
   type        = any


### PR DESCRIPTION
Adds support for the [github_branch ](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch) resource as requested in #107 