### PR TITLE
feat: add v4 branch protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ A [Terraform] module for creating a public or private repository on [Github].
     - [Collaborator Configuration](#collaborator-configuration)
     - [Branches Configuration](#branches-configuration)
     - [Deploy Keys Configuration](#deploy-keys-configuration)
-    - [Branch Protections Configuration](#branch-protections-configuration)
+    - [Branch Protections v3 Configuration](#branch-protections-v3-configuration)
+    - [Branch Protections v4 Configuration](#branch-protections-v4-configuration)
     - [Issue Labels Configuration](#issue-labels-configuration)
     - [Projects Configuration](#projects-configuration)
     - [Webhooks Configuration](#webhooks-configuration)
@@ -528,11 +529,11 @@ This is due to some terraform limitation and we will update the module once terr
 
     Default is `"md5(key)"`.
 
-#### Branch Protections Configuration
+#### Branch Protections v3 Configuration
 
 - [**`branch_protections_v3`**](#var-branch_protections_v3): *(Optional `list(branch_protection_v3)`)*<a name="var-branch_protections_v3"></a>
 
-  This resource allows you to configure branch protection for repositories in your organization.
+  This resource allows you to configure v3 branch protection for repositories in your organization.
   When applied, the branch will be protected from forced pushes and deletion.
   Additional constraints, such as required status checks or restrictions on users and teams, can also be configured.
 
@@ -651,6 +652,135 @@ This is due to some terraform limitation and we will update the module once terr
   This argument is ignored if `branch_protections_v3` is used. Please see `branch_protections_v3` for supported attributes.
 
   Default is `[]`.
+
+#### Branch Protections v4 Configuration
+
+- [**`branch_protections_v4`**](#var-branch_protections_v4): *(Optional `map(branch_protection_v4)`)*<a name="var-branch_protections_v4"></a>
+
+  This map allows you to configure v4 branch protection for repositories in your organization.
+
+  Each element in the map is a branch to be protected and the value the corresponding to the desired configuration for the branch.
+
+  When applied, the branch will be protected from forced pushes and deletion.
+  Additional constraints, such as required status checks or restrictions on users and teams, can also be configured.
+
+  **_NOTE_** This will take precedence over v3 branch protections.
+
+  Default is `null`.
+
+  Each `branch_protection_v4` object in the map accepts the following attributes:
+
+  - [**`allows_deletions`**](#attr-branch_protections_v4-allows_deletions): *(Optional `bool`)*<a name="attr-branch_protections_v4-allows_deletions"></a>
+
+    Setting this to true to allow the branch to be deleted.
+
+    Default is `false`.
+
+  - [**`allows_force_pushes`**](#attr-branch_protections_v4-allows_force_pushes): *(Optional `bool`)*<a name="attr-branch_protections_v4-allows_force_pushes"></a>
+
+    Setting this to true to allow force pushes on the branch.
+
+    Default is `false`.
+
+  - [**`blocks_creations`**](#attr-branch_protections_v4-blocks_creations): *(Optional `bool`)*<a name="attr-branch_protections_v4-blocks_creations"></a>
+
+    Setting this to true will block creating the branch.
+
+    Default is `false`.
+
+  - [**`enforce_admins`**](#attr-branch_protections_v4-enforce_admins): *(Optional `bool`)*<a name="attr-branch_protections_v4-enforce_admins"></a>
+
+    Setting this to true enforces status checks for repository administrators.
+
+    Default is `false`.
+
+  - [**`push_restrictions`**](#attr-branch_protections_v4-push_restrictions): *(Optional `list(string)`)*<a name="attr-branch_protections_v4-push_restrictions"></a>
+
+    The list of actor Names/IDs that may push to the branch.
+    Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
+
+    Default is `[]`.
+
+  - [**`require_conversation_resolution`**](#attr-branch_protections_v4-require_conversation_resolution): *(Optional `bool`)*<a name="attr-branch_protections_v4-require_conversation_resolution"></a>
+
+    Setting this to true requires all conversations on code must be resolved before a pull request can be merged.
+
+    Default is `false`.
+
+  - [**`require_signed_commits`**](#attr-branch_protections_v4-require_signed_commits): *(Optional `bool`)*<a name="attr-branch_protections_v4-require_signed_commits"></a>
+
+    Setting this to true requires all commits to be signed with GPG.
+
+    Default is `false`.
+
+  - [**`required_linear_history`**](#attr-branch_protections_v4-required_linear_history): *(Optional `bool`)*<a name="attr-branch_protections_v4-required_linear_history"></a>
+
+    Setting this to true enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
+
+    Default is `false`.
+
+  - [**`required_pull_request_reviews`**](#attr-branch_protections_v4-required_pull_request_reviews): *(Optional `object(required_pull_request_reviews)`)*<a name="attr-branch_protections_v4-required_pull_request_reviews"></a>
+
+    Enforce restrictions for pull request reviews.
+
+    Default is `null`.
+
+    The `required_pull_request_reviews` object accepts the following attributes:
+
+    - [**`dismiss_stale_reviews`**](#attr-branch_protections_v4-required_pull_request_reviews-dismiss_stale_reviews): *(Optional `bool`)*<a name="attr-branch_protections_v4-required_pull_request_reviews-dismiss_stale_reviews"></a>
+
+      Dismiss approved reviews automatically when a new commit is pushed.
+
+      Default is `true`.
+
+    - [**`dismissal_restrictions`**](#attr-branch_protections_v4-required_pull_request_reviews-dismissal_restrictions): *(Optional `list(string)`)*<a name="attr-branch_protections_v4-required_pull_request_reviews-dismissal_restrictions"></a>
+
+      The list of actor Names/IDs with dismissal access.
+      If not empty, restrict_dismissals is ignored.
+      Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
+
+      Default is `[]`.
+
+    - [**`pull_request_bypassers`**](#attr-branch_protections_v4-required_pull_request_reviews-pull_request_bypassers): *(Optional `list(string)`)*<a name="attr-branch_protections_v4-required_pull_request_reviews-pull_request_bypassers"></a>
+
+      The list of actor Names/IDs that are allowed to bypass pull request requirements.
+      Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
+
+      Default is `[]`.
+
+    - [**`require_code_owner_reviews`**](#attr-branch_protections_v4-required_pull_request_reviews-require_code_owner_reviews): *(Optional `bool`)*<a name="attr-branch_protections_v4-required_pull_request_reviews-require_code_owner_reviews"></a>
+
+      Require an approved review in pull requests including files with a designated code owner.
+
+      Default is `false`.
+
+    - [**`required_approving_review_count`**](#attr-branch_protections_v4-required_pull_request_reviews-required_approving_review_count): *(Optional `number`)*<a name="attr-branch_protections_v4-required_pull_request_reviews-required_approving_review_count"></a>
+
+      Require x number of approvals to satisfy branch protection requirements.
+      If this is specified it must be a number between 0-6.
+
+      Default is `0`.
+
+  - [**`required_status_checks`**](#attr-branch_protections_v4-required_status_checks): *(Optional `object(required_status_checks)`)*<a name="attr-branch_protections_v4-required_status_checks"></a>
+
+    Enforce restrictions for required status checks.
+    See Required Status Checks below for details.
+
+    Default is `null`.
+
+    The `required_status_checks` object accepts the following attributes:
+
+    - [**`strict`**](#attr-branch_protections_v4-required_status_checks-strict): *(Optional `bool`)*<a name="attr-branch_protections_v4-required_status_checks-strict"></a>
+
+      Require branches to be up to date before merging.
+
+      Default is `false`.
+
+    - [**`contexts`**](#attr-branch_protections_v4-required_status_checks-contexts): *(Optional `list(string)`)*<a name="attr-branch_protections_v4-required_status_checks-contexts"></a>
+
+      The list of status checks to require in order to merge into this branch. If default is `[]` no status checks are required.
+
+      Default is `[]`.
 
 #### Issue Labels Configuration
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -677,13 +677,13 @@ section {
       }
 
       section {
-        title = "Branch Protections Configuration"
+        title = "Branch Protections v3 Configuration"
 
         variable "branch_protections_v3" {
           type        = list(branch_protection_v3)
           default     = []
           description = <<-END
-            This resource allows you to configure branch protection for repositories in your organization.
+            This resource allows you to configure v3 branch protection for repositories in your organization.
             When applied, the branch will be protected from forced pushes and deletion.
             Additional constraints, such as required status checks or restrictions on users and teams, can also be configured.
           END
@@ -829,6 +829,167 @@ section {
             **_DEPRECATED_** To ensure compatibility with future versions of this module, please use `branch_protections_v3`.
             This argument is ignored if `branch_protections_v3` is used. Please see `branch_protections_v3` for supported attributes.
           END
+        }
+      }
+
+      section {
+        title = "Branch Protections v4 Configuration"
+
+        variable "branch_protections_v4" {
+          type        = map(branch_protection_v4)
+          default     = null
+          description = <<-END
+            This map allows you to configure v4 branch protection for repositories in your organization.
+
+            Each element in the map is a branch to be protected and the value the corresponding to the desired configuration for the branch.
+
+            When applied, the branch will be protected from forced pushes and deletion.
+            Additional constraints, such as required status checks or restrictions on users and teams, can also be configured.
+
+            **_NOTE_** This will take precedence over v3 branch protections.
+          END
+
+          attribute "allows_deletions" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true to allow the branch to be deleted.
+            END
+          }
+
+          attribute "allows_force_pushes" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true to allow force pushes on the branch.
+            END
+          }
+
+          attribute "blocks_creations" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true will block creating the branch.
+            END
+          }
+
+          attribute "enforce_admins" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true enforces status checks for repository administrators.
+            END
+          }
+
+          attribute "push_restrictions" {
+            type        = list(string)
+            default     = []
+            description = <<-END
+              The list of actor Names/IDs that may push to the branch.
+              Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
+            END
+          }
+
+          attribute "require_conversation_resolution" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true requires all conversations on code must be resolved before a pull request can be merged.
+            END
+          }
+
+          attribute "require_signed_commits" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true requires all commits to be signed with GPG.
+            END
+          }
+
+          attribute "required_linear_history" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Setting this to true enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
+            END
+          }
+
+          attribute "required_pull_request_reviews" {
+            type        = object(required_pull_request_reviews)
+            default     = null
+            description = <<-END
+              Enforce restrictions for pull request reviews.
+            END
+
+            attribute "dismiss_stale_reviews" {
+              type        = bool
+              default     = true
+              description = <<-END
+                Dismiss approved reviews automatically when a new commit is pushed.
+              END
+            }
+
+            attribute "dismissal_restrictions" {
+              type        = list(string)
+              default     = []
+              description = <<-END
+                The list of actor Names/IDs with dismissal access.
+                If not empty, restrict_dismissals is ignored.
+                Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
+              END
+            }
+
+            attribute "pull_request_bypassers" {
+              type        = list(string)
+              default     = []
+              description = <<-END
+                The list of actor Names/IDs that are allowed to bypass pull request requirements.
+                Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
+              END
+            }
+
+            attribute "require_code_owner_reviews" {
+              type        = bool
+              default     = false
+              description = <<-END
+                Require an approved review in pull requests including files with a designated code owner.
+              END
+            }
+
+            attribute "required_approving_review_count" {
+              type        = number
+              default     = 0
+              description = <<-END
+                Require x number of approvals to satisfy branch protection requirements.
+                If this is specified it must be a number between 0-6.
+              END
+            }
+          }
+
+          attribute "required_status_checks" {
+            type        = object(required_status_checks)
+            default     = null
+            description = <<-END
+              Enforce restrictions for required status checks.
+              See Required Status Checks below for details.
+            END
+
+            attribute "strict" {
+              type        = bool
+              default     = false
+              description = <<-END
+                Require branches to be up to date before merging.
+              END
+            }
+
+            attribute "contexts" {
+              type        = list(string)
+              default     = []
+              description = <<-END
+                The list of status checks to require in order to merge into this branch. If default is `[]` no status checks are required.
+              END
+            }
+          }
         }
       }
 

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,6 @@ resource "github_repository" "repository" {
   lifecycle {
     ignore_changes = [
       auto_init,
-      branches,
       license_template,
       gitignore_template,
       template,
@@ -180,7 +179,7 @@ resource "github_branch_default" "default" {
 # https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "github_branch_protection" "this" {
+resource "github_branch_protection" "branch_protection" {
   for_each = length(coalesce(var.branch_protections_v4, {})) > 0 ? var.branch_protections_v4 : {}
 
   # ensure we have all members and collaborators added before applying

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ resource "github_branch_default" "default" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "github_branch_protection" "this" {
-  for_each = coalesce(var.branch_protections_v4, {})
+  for_each = length(coalesce(var.branch_protections_v4, {})) > 0 ? var.branch_protections_v4 : {}
 
   # ensure we have all members and collaborators added before applying
   # any configuration for them
@@ -232,7 +232,7 @@ resource "github_branch_protection" "this" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "github_branch_protection_v3" "branch_protection" {
-  count = var.branch_protections_v4 == null ? length(local.branch_protections_v3) : 0
+  count = length(coalesce(var.branch_protections_v4, {})) == 0 ? length(local.branch_protections_v3) : 0
 
   # ensure we have all members and collaborators added before applying
   # any configuration for them

--- a/variables.tf
+++ b/variables.tf
@@ -351,6 +351,53 @@ variable "branch_protections_v3" {
   # ]
 }
 
+variable "branch_protections_v4" {
+  description = "(Optional) A list of v4 branch protections to apply to the repository. Default is {}."
+  type = map(
+    object(
+      {
+        allows_deletions                = optional(bool, false)
+        allows_force_pushes             = optional(bool, false)
+        blocks_creations                = optional(bool, false)
+        enforce_admins                  = optional(bool, false)
+        push_restrictions               = optional(list(string), [])
+        require_conversation_resolution = optional(bool, false)
+        require_signed_commits          = optional(bool, false)
+        required_linear_history         = optional(bool, false)
+        required_pull_request_reviews = optional(object(
+          {
+            dismiss_stale_reviews           = optional(bool, false)
+            dismissal_restrictions          = optional(list(string), [])
+            pull_request_bypassers          = optional(list(string), [])
+            require_code_owner_reviews      = optional(bool, false)
+            required_approving_review_count = optional(number, 0)
+          }
+        ))
+        required_status_checks = optional(object(
+          {
+            strict   = optional(bool, false)
+            contexts = optional(list(string), [])
+          }
+        ))
+      }
+    )
+  )
+  default = null
+
+  validation {
+    condition = alltrue(
+      [
+        for cfg in coalesce(var.branch_protections_v4, {}) : try(
+          cfg.required_pull_request_reviews.required_approving_review_count >= 0
+          && cfg.required_pull_request_reviews.required_approving_review_count <= 6,
+          true
+        )
+      ]
+    )
+    error_message = "The value for branch_protections_v4.required_pull_request_reviews.required_approving_review_count must be between 0 and 6, inclusively."
+  }
+}
+
 variable "issue_labels_merge_with_github_labels" {
   description = "(Optional) Specify if you want to merge and control githubs default set of issue labels."
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.3"
 
   # branch_protections_v3 are broken in >= 5.3
   required_providers {


### PR DESCRIPTION
Adds v4 branch protections as a separate resource. If v4 branch protections are set, then it will disable the v3 branch protection resource to prevent any conflicts.

Resolves #124 

Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>