### PR TITLE
Add support for allow_update_branch and update provider min version

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,7 @@
+rule "terraform_unused_declarations" {
+  enabled = false
+}
+
+rule "terraform_required_providers" {
+  enabled = false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `allow_update_branch`.
+
+### Changed
+
+- BREAKING CHANGE: Bump minimum supported version of the GitHub provider to `v5.16`
+  as it contains a [critical fix](https://github.com/integrations/terraform-provider-github/pull/1415) for branch protections.
+
 ## [0.18.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING CHANGE: Bump minimum supported version of the GitHub provider to `v5.16`
   as it contains a [critical fix](https://github.com/integrations/terraform-provider-github/pull/1415) for branch protections.
+- BREAKING CHANGE: Rename `required_status_checks.contexts` to `required_status_checks.checks` as contexts is
+  depcrecated in v3 branch protections
 
 ## [0.18.0]
 

--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ This is due to some terraform limitation and we will update the module once terr
 
       Default is `false`.
 
-    - [**`contexts`**](#attr-branch_protections_v3-required_status_checks-contexts): *(Optional `list(string)`)*<a name="attr-branch_protections_v3-required_status_checks-contexts"></a>
+    - [**`checks`**](#attr-branch_protections_v3-required_status_checks-checks): *(Optional `list(string)`)*<a name="attr-branch_protections_v3-required_status_checks-checks"></a>
 
       The list of status checks to require in order to merge into this branch. If default is `[]` no status checks are required.
 
@@ -749,7 +749,7 @@ This is due to some terraform limitation and we will update the module once terr
 
       Default is `false`.
 
-    - [**`contexts`**](#attr-branch_protections_v4-required_status_checks-contexts): *(Optional `list(string)`)*<a name="attr-branch_protections_v4-required_status_checks-contexts"></a>
+    - [**`checks`**](#attr-branch_protections_v4-required_status_checks-checks): *(Optional `list(string)`)*<a name="attr-branch_protections_v4-required_status_checks-checks"></a>
 
       The list of status checks to require in order to merge into this branch. If default is `[]` no status checks are required.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/mineiros-io/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg)](https://github.com/mineiros-io/terraform-github-repository/actions)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/mineiros-io/terraform-github-repository.svg?label=latest&sort=semver)](https://github.com/mineiros-io/terraform-github-repository/releases)
 [![Terraform Version](https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform)](https://github.com/hashicorp/terraform/releases)
-[![Github Provider Version](https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform)](https://github.com/terraform-providers/terraform-provider-github/releases)
+[![Github Provider Version](https://img.shields.io/badge/GH-5.16+-F8991D.svg?logo=terraform)](https://github.com/terraform-providers/terraform-provider-github/releases)
 [![Join Slack](https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack)](https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg)
 
 # terraform-github-repository
@@ -649,6 +649,12 @@ This is due to some terraform limitation and we will update the module once terr
 
     Default is `false`.
 
+  - [**`allow_update_branch`**](#attr-branch_protections_v4-allow_update_branch): *(Optional `bool`)*<a name="attr-branch_protections_v4-allow_update_branch"></a>
+
+    Set to `true` to always suggest updating pull request branches.
+
+    Default is `false`.
+
   - [**`blocks_creations`**](#attr-branch_protections_v4-blocks_creations): *(Optional `bool`)*<a name="attr-branch_protections_v4-blocks_creations"></a>
 
     Setting this to `true` will block creating the branch.
@@ -1078,7 +1084,7 @@ Run `make help` to see details on each available target.
 This module is licensed under the Apache License Version 2.0, January 2004.
 Please see [LICENSE] for full details.
 
-Copyright &copy; 2020-2022 [Mineiros GmbH][homepage]
+Copyright &copy; 2020-2023 [Mineiros GmbH][homepage]
 
 
 <!-- References -->
@@ -1097,7 +1103,7 @@ Copyright &copy; 2020-2022 [Mineiros GmbH][homepage]
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform
 [badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
-[badge-tf-gh]: https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform
+[badge-tf-gh]: https://img.shields.io/badge/GH-5.16+-F8991D.svg?logo=terraform
 [releases-github-provider]: https://github.com/terraform-providers/terraform-provider-github/releases
 [build-status]: https://github.com/mineiros-io/terraform-github-repository/actions
 [releases-github]: https://github.com/mineiros-io/terraform-github-repository/releases

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -21,7 +21,7 @@ header {
   }
 
   badge "tf-gh" {
-    image = "https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform"
+    image = "https://img.shields.io/badge/GH-5.16+-F8991D.svg?logo=terraform"
     url   = "https://github.com/terraform-providers/terraform-provider-github/releases"
     text  = "Github Provider Version"
   }
@@ -837,6 +837,14 @@ section {
             END
           }
 
+          attribute "allow_update_branch" {
+            type        = bool
+            default     = false
+            description = <<-END
+              Set to `true` to always suggest updating pull request branches.
+            END
+          }
+
           attribute "blocks_creations" {
             type        = bool
             default     = false
@@ -1442,7 +1450,7 @@ section {
       This module is licensed under the Apache License Version 2.0, January 2004.
       Please see [LICENSE] for full details.
 
-      Copyright &copy; 2020-2022 [Mineiros GmbH][homepage]
+      Copyright &copy; 2020-2023 [Mineiros GmbH][homepage]
     END
   }
 }
@@ -1491,7 +1499,7 @@ references {
     value = "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack"
   }
   ref "badge-tf-gh" {
-    value = "https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform"
+    value = "https://img.shields.io/badge/GH-5.16+-F8991D.svg?logo=terraform"
   }
   ref "releases-github-provider" {
     value = "https://github.com/terraform-providers/terraform-provider-github/releases"

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -701,7 +701,7 @@ section {
               END
             }
 
-            attribute "contexts" {
+            attribute "checks" {
               type        = list(string)
               default     = []
               description = <<-END
@@ -967,7 +967,7 @@ section {
               END
             }
 
-            attribute "contexts" {
+            attribute "checks" {
               type        = list(string)
               default     = []
               description = <<-END

--- a/examples/public-repository/README.md
+++ b/examples/public-repository/README.md
@@ -111,7 +111,7 @@ Run `terraform destroy` to destroy all resources again.
 [main.tf]: https://github.com/mineiros-io/terraform-github-repository/blob/main/examples/public-respository/main.tf
 [homepage]: https://mineiros.io/?ref=terraform-github-repository
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
-[badge-terraform]: https://img.shields.io/badge/terraform-1.x%20|0.15%20|0.14%20|%200.13%20|%200.12.20+-623CE4.svg?logo=terraform
+[badge-terraform]: https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform
 [badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 [releases-terraform]: https://github.com/hashicorp/terraform/releases
 [apache20]: https://opensource.org/licenses/Apache-2.0

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -13,22 +13,23 @@ module "repository" {
     module.team
   ]
 
-  name               = "my-public-repository"
-  description        = "A description of the repository."
-  homepage_url       = "https://github.com/mineiros-io"
-  visibility         = "public"
-  has_issues         = true
-  has_projects       = false
-  has_wiki           = true
-  allow_merge_commit = true
-  allow_rebase_merge = false
-  allow_squash_merge = false
-  allow_auto_merge   = true
-  has_downloads      = false
-  auto_init          = true
-  gitignore_template = "Terraform"
-  license_template   = "mit"
-  topics             = ["terraform", "unit-test"]
+  name                = "my-public-repository"
+  description         = "A description of the repository."
+  homepage_url        = "https://github.com/mineiros-io"
+  visibility          = "public"
+  has_issues          = true
+  has_projects        = false
+  has_wiki            = true
+  allow_merge_commit  = true
+  allow_rebase_merge  = false
+  allow_squash_merge  = false
+  allow_auto_merge    = true
+  has_downloads       = false
+  auto_init           = true
+  gitignore_template  = "Terraform"
+  license_template    = "mit"
+  topics              = ["terraform", "unit-test"]
+  allow_update_branch = true
 
   admin_team_ids = [
     module.team.team.id

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -13,22 +13,22 @@ module "repository" {
     module.team
   ]
 
-  name                = "my-public-repository"
-  description         = "A description of the repository."
-  homepage_url        = "https://github.com/mineiros-io"
-  visibility          = "public"
-  has_issues          = true
-  has_projects        = false
-  has_wiki            = true
-  allow_merge_commit  = true
-  allow_rebase_merge  = false
-  allow_squash_merge  = false
-  allow_auto_merge    = true
-  has_downloads       = false
-  auto_init           = true
-  gitignore_template  = "Terraform"
-  license_template    = "mit"
-  topics              = ["terraform", "unit-test"]
+  name               = "my-public-repository"
+  description        = "A description of the repository."
+  homepage_url       = "https://github.com/mineiros-io"
+  visibility         = "public"
+  has_issues         = true
+  has_projects       = false
+  has_wiki           = true
+  allow_merge_commit = true
+  allow_rebase_merge = false
+  allow_squash_merge = false
+  allow_auto_merge   = true
+  has_downloads      = false
+  auto_init          = true
+  gitignore_template = "Terraform"
+  license_template   = "mit"
+  topics             = ["terraform", "unit-test"]
   allow_update_branch = true
 
   admin_team_ids = [

--- a/main.tf
+++ b/main.tf
@@ -56,8 +56,8 @@ locals {
     for b in local.branch_protections_v3 :
     length(keys(b.required_status_checks)) > 0 ? [
       merge({
-        strict   = null
-        contexts = []
+        strict = null
+        checks = []
     }, b.required_status_checks)] : []
   ]
 
@@ -260,8 +260,8 @@ resource "github_branch_protection_v3" "branch_protection" {
     for_each = local.required_status_checks[count.index]
 
     content {
-      strict   = required_status_checks.value.strict
-      contexts = required_status_checks.value.contexts
+      strict = required_status_checks.value.strict
+      checks = required_status_checks.value.checks
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,7 @@ resource "github_repository" "repository" {
   license_template       = local.license_template
   archived               = var.archived
   topics                 = local.topics
+  allow_update_branch    = var.allow_update_branch
 
   archive_on_destroy   = var.archive_on_destroy
   vulnerability_alerts = local.vulnerability_alerts

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -40,6 +40,7 @@ module "repository" {
   allow_rebase_merge     = var.allow_rebase_merge
   allow_squash_merge     = var.allow_squash_merge
   allow_auto_merge       = var.allow_auto_merge
+  allow_update_branch    = true
   delete_branch_on_merge = var.delete_branch_on_merge
   is_template            = var.is_template
   has_downloads          = var.has_downloads

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -119,8 +119,8 @@ module "repository" {
       require_signed_commits          = true
 
       required_status_checks = {
-        strict   = true
-        contexts = ["ci/travis"]
+        strict = true
+        checks = ["ci/travis"]
       }
 
       required_pull_request_reviews = {

--- a/test/unit-complete/provider.tf
+++ b/test/unit-complete/provider.tf
@@ -6,8 +6,6 @@ terraform {
   required_providers {
     github = {
       source = "integrations/github"
-      # mask providers with broken branch protection v3 imlementation
-      version = "~> 5.0, !=5.3.0, !=5.4.0, !=5.5.0, !=5.6.0, !=5.7.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "allow_auto_merge" {
   default     = null
 }
 
+variable "allow_update_branch" {
+  description = "(Optional) Set to true to always suggest updating pull request branches."
+  type        = bool
+  default     = false
+}
+
 variable "delete_branch_on_merge" {
   description = "(Optional) Whether or not to delete the merged branch after merging a pull request. (Default: false)"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -284,8 +284,8 @@ variable "branch_protections_v3" {
   #   enforce_admins         = bool
   #   require_signed_commits = bool
   #   required_status_checks = object({
-  #     strict   = bool
-  #     contexts = list(string)
+  #     strict = bool
+  #     checks = list(string)
   #   })
   #   required_pull_request_reviews = object({
   #     dismiss_stale_reviews           = bool
@@ -311,7 +311,7 @@ variable "branch_protections_v3" {
   #
   #     required_status_checks = {
   #       strict   = false
-  #       contexts = ["ci/travis"]
+  #       checks   = ["ci/travis"]
   #     }
   #
   #     required_pull_request_reviews = {

--- a/versions.tf
+++ b/versions.tf
@@ -5,11 +5,10 @@
 terraform {
   required_version = "~> 1.0"
 
-  # branch_protections_v3 are broken in >= 5.3
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.20, < 6.0"
+      version = ">= 5.16, < 6.0"
     }
   }
 }


### PR DESCRIPTION
- BREAKING CHANGE: Add support for `allow_update_branch`. Bump minimum supported version of the GitHub provider to `v5.16`
  as it contains a [critical fix](https://github.com/integrations/terraform-provider-github/pull/1415) for branch protections.