### PR TITLE
feat: add support for `is_alphanumeric` in `autolink_reference`

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,12 @@ This is due to some terraform limitation and we will update the module once terr
 
     The template of the target URL used for the links; must be a valid URL and contain `<num>` for the reference number.
 
+  - [**`is_alphanumeric`**](#attr-autolink_references-is_alphanumeric): *(Optional `bool`)*<a name="attr-autolink_references-is_alphanumeric"></a>
+
+    Specify if your autolink reference is alphanumeric or numeric identifier.
+
+    Default is `true`.
+
 #### App Installations
 
 - [**`app_installations`**](#var-app_installations): *(Optional `set(string)`)*<a name="var-app_installations"></a>

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -1207,6 +1207,15 @@ section {
                 The template of the target URL used for the links; must be a valid URL and contain `<num>` for the reference number.
               END
           }
+
+          attribute "is_alphanumeric" {
+            required    = false
+            type        = bool
+            default     = true
+            description = <<-END
+                Specify if your autolink reference is alphanumeric or numeric identifier.
+              END
+          }
         }
       }
 

--- a/main.tf
+++ b/main.tf
@@ -551,6 +551,7 @@ resource "github_repository_autolink_reference" "repository_autolink_reference" 
   repository          = github_repository.repository.name
   key_prefix          = each.value.key_prefix
   target_url_template = each.value.target_url_template
+  is_alphanumeric     = each.value.is_alphanumeric
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -525,6 +525,7 @@ variable "autolink_references" {
   type = list(object({
     key_prefix          = string
     target_url_template = string
+    is_alphanumeric     = optional(bool)
   }))
 
   # Example:
@@ -532,6 +533,7 @@ variable "autolink_references" {
   #   {
   #     key_prefix          = "TICKET-"
   #     target_url_template = "https://hello.there/TICKET?query=<num>"
+  #     is_alphanumeric     = true
   #   }
   # ]
 

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.20, < 6.0"
+      version = ">= 5.8, < 6.0"
     }
   }
 }


### PR DESCRIPTION
- add support for `is_alphanumeric` in `autolink_reference` with default being `true`

fix #142