### PR TITLE
BREAKING: remove v3 and deprecations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
     name: Static Analysis
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run pre-commit
-        run: make test/docker/pre-commit
+        uses: docker://ghcr.io/antonbabenko/pre-commit-terraform:latest
 
   unit-tests:
     needs: pre-commit
@@ -29,7 +29,7 @@ jobs:
     name: Unit Tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for Terraform file changes
         uses: getsentry/paths-filter@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/mineiros-io/pre-commit-hooks
-    rev: v0.4.1
+    rev: v0.5.1
     hooks:
       - id: terraform-fmt
       - id: terraform-validate

--- a/examples/public-repository/README.md
+++ b/examples/public-repository/README.md
@@ -62,7 +62,7 @@ module "repository" {
 
       required_status_checks = {
         strict   = true
-        contexts = ["ci/travis"]
+        checks   = ["ci/travis"]
       }
 
       required_pull_request_reviews = {

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -6,7 +6,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 module "repository" {
-  source  = "../.."
+  source = "../.."
 
   module_depends_on = [
     module.team
@@ -52,8 +52,8 @@ module "repository" {
       require_signed_commits          = true
 
       required_status_checks = {
-        strict   = true
-        checks   = ["ci/travis"]
+        strict = true
+        checks = ["ci/travis"]
       }
 
       required_pull_request_reviews = {
@@ -75,7 +75,7 @@ module "repository" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "team" {
-  source  = "github.com/kevcube/terraform-github-team?ref=a0b2c37"
+  source = "github.com/kevcube/terraform-github-team?ref=a0b2c37"
 
   name        = "DevOps"
   description = "The DevOps Team"

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -6,8 +6,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 module "repository" {
-  source  = "mineiros-io/repository/github"
-  version = "~> 0.13.0"
+  source  = "../.."
 
   module_depends_on = [
     module.team
@@ -24,7 +23,6 @@ module "repository" {
   allow_rebase_merge = false
   allow_squash_merge = false
   allow_auto_merge   = true
-  has_downloads      = false
   auto_init          = true
   gitignore_template = "Terraform"
   license_template   = "mit"
@@ -47,9 +45,8 @@ module "repository" {
 
   admin_collaborators = ["terraform-test-user-1"]
 
-  branch_protections = [
-    {
-      branch                          = "main"
+  branch_protections = {
+    "main" = {
       enforce_admins                  = true
       require_conversation_resolution = true
       require_signed_commits          = true
@@ -70,7 +67,7 @@ module "repository" {
         teams = [module.team.name]
       }
     }
-  ]
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -78,8 +75,7 @@ module "repository" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "team" {
-  source  = "mineiros-io/team/github"
-  version = "~> 0.8.0"
+  source  = "github.com/kevcube/terraform-github-team?ref=a0b2c37"
 
   name        = "DevOps"
   description = "The DevOps Team"

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -56,7 +56,7 @@ module "repository" {
 
       required_status_checks = {
         strict   = true
-        contexts = ["ci/travis"]
+        checks   = ["ci/travis"]
       }
 
       required_pull_request_reviews = {

--- a/examples/public-repository/provider.tf
+++ b/examples/public-repository/provider.tf
@@ -1,12 +1,12 @@
 provider "github" {}
 
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.7"
 
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 4.0"
+      version = "~> 6"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,12 @@ resource "github_repository" "repository" {
   archived               = var.archived
   topics                 = local.topics
 
+  merge_commit_message = var.merge_commit_message
+  merge_commit_title   = var.merge_commit_title
+
+  squash_merge_commit_message = var.squash_merge_commit_message
+  squash_merge_commit_title   = var.squash_merge_commit_title
+
   archive_on_destroy   = var.archive_on_destroy
   vulnerability_alerts = local.vulnerability_alerts
 

--- a/secrets.tf
+++ b/secrets.tf
@@ -2,18 +2,18 @@
 # Action Secrets
 # ---------------------------------------------------------------------------------------------------------------------
 
-locals {
-  plaintext_secrets = { for name, value in var.plaintext_secrets : name => { plaintext = value } }
-  encrypted_secrets = { for name, value in var.encrypted_secrets : name => { encrypted = value } }
-
-  secrets = merge(local.plaintext_secrets, local.encrypted_secrets)
-}
-
-resource "github_actions_secret" "repository_secret" {
-  for_each = local.secrets
+resource "github_actions_secret" "plaintext_repository_secret" {
+  for_each = var.plaintext_secrets
 
   repository      = github_repository.repository.name
   secret_name     = each.key
-  plaintext_value = try(each.value.plaintext, null)
-  encrypted_value = try(each.value.encrypted, null)
+  plaintext_value = each.value
+}
+
+resource "github_actions_secret" "repository_secret" {
+  for_each = var.encrypted_secrets
+
+  repository      = github_repository.repository.name
+  secret_name     = each.key
+  encrypted_value = each.value.encrypted
 }

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -48,6 +48,7 @@ module "repository" {
   license_template       = var.license_template
   archived               = false
   topics                 = var.topics
+  archive_on_destroy     = false
 
   branches = [
     {
@@ -58,7 +59,7 @@ module "repository" {
     },
   ]
 
-  admin_collaborators = ["terraform-test-user-1"]
+  admin_collaborators = ["kevcube"]
 
   admin_team_ids = [
     github_team.team.id
@@ -118,8 +119,8 @@ module "repository" {
       require_signed_commits          = true
 
       required_status_checks = {
-        strict   = true
-        contexts = ["ci/travis"]
+        strict = true
+        checks = ["ci/travis"]
       }
 
       required_pull_request_reviews = {
@@ -169,10 +170,11 @@ module "repository" {
 module "repository-with-defaults" {
   source = "../.."
 
-  name           = var.repository_with_defaults_name
-  description    = var.repository_with_defaults_description
-  defaults       = var.repository_defaults
-  default_branch = "development"
+  name               = var.repository_with_defaults_name
+  description        = var.repository_with_defaults_description
+  defaults           = var.repository_defaults
+  default_branch     = "development"
+  archive_on_destroy = false
 
   branches = [
     { name = "development" },

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -32,7 +32,7 @@ module "repository" {
   name                   = var.name
   description            = var.description
   homepage_url           = var.url
-  private                = false
+  visibility             = "public"
   has_issues             = var.has_issues
   has_projects           = var.has_projects
   has_wiki               = var.has_wiki
@@ -42,7 +42,6 @@ module "repository" {
   allow_auto_merge       = var.allow_auto_merge
   delete_branch_on_merge = var.delete_branch_on_merge
   is_template            = var.is_template
-  has_downloads          = var.has_downloads
   auto_init              = var.auto_init
   gitignore_template     = var.gitignore_template
   license_template       = var.license_template
@@ -50,14 +49,10 @@ module "repository" {
   topics                 = var.topics
   archive_on_destroy     = false
 
-  branches = [
-    {
-      name = "develop"
-    },
-    {
-      name = "staging"
-    },
-  ]
+  branches = {
+    develop = {},
+    staging = {},
+  }
 
   admin_collaborators = ["kevcube"]
 
@@ -87,9 +82,8 @@ module "repository" {
     secret       = var.webhook_secret
   }]
 
-  branch_protections_v4 = [
-    {
-      pattern = "staging"
+  branch_protections = {
+    staging = {
 
       allows_deletions                = false
       allows_force_pushes             = false
@@ -109,39 +103,7 @@ module "repository" {
         strict = true
       }
     }
-  ]
-
-  branch_protections_v3 = [
-    {
-      branch                          = "main"
-      enforce_admins                  = true
-      require_conversation_resolution = true
-      require_signed_commits          = true
-
-      required_status_checks = {
-        strict = true
-        checks = ["ci/travis"]
-      }
-
-      required_pull_request_reviews = {
-        dismiss_stale_reviews           = true
-        dismissal_users                 = [var.team_user]
-        dismissal_teams                 = [github_team.team.name]
-        require_code_owner_reviews      = true
-        required_approving_review_count = 1
-      }
-
-      restrictions = {
-        users = [var.team_user]
-        teams = [github_team.team.name]
-      }
-    },
-    {
-      branch                 = "develop"
-      enforce_admins         = true
-      require_signed_commits = true
-    }
-  ]
+  }
 
   issue_labels = var.issue_labels
 
@@ -172,13 +134,10 @@ module "repository-with-defaults" {
 
   name               = var.repository_with_defaults_name
   description        = var.repository_with_defaults_description
-  defaults           = var.repository_defaults
   default_branch     = "development"
   archive_on_destroy = false
 
-  branches = [
-    { name = "development" },
-  ]
+  branches = { development = {} }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/test/unit-complete/provider.tf
+++ b/test/unit-complete/provider.tf
@@ -1,4 +1,6 @@
-provider "github" {}
+provider "github" {
+  owner = "kbc-trading"
+}
 
 terraform {
   required_version = "~> 1.0"
@@ -11,7 +13,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 2.1"
+      version = "~> 4"
     }
   }
 }

--- a/test/unit-complete/provider.tf
+++ b/test/unit-complete/provider.tf
@@ -1,6 +1,4 @@
-provider "github" {
-  owner = "kbc-trading"
-}
+provider "github" {}
 
 terraform {
   required_version = "~> 1.0"
@@ -9,7 +7,7 @@ terraform {
     github = {
       source = "integrations/github"
       # mask providers with broken branch protection v3 imlementation
-      version = "~> 5.0, !=5.3.0, !=5.4.0, !=5.5.0, !=5.6.0, !=5.7.0"
+      version = "~> 6"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/test/unit-complete/variables.tf
+++ b/test/unit-complete/variables.tf
@@ -146,7 +146,7 @@ variable "team_description" {
 variable "team_user" {
   description = "The user that should be added to the created team."
   type        = string
-  default     = "terraform-test-user"
+  default     = "kevcube"
 }
 
 variable "repository_defaults" {

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,30 @@ variable "topics" {
   default     = null
 }
 
+variable "merge_commit_title" {
+  description = "Can be PR_TITLE or MERGE_MESSAGE for a default merge commit title. Applicable only if allow_merge_commit is true."
+  type        = string
+  default     = null
+}
+
+variable "merge_commit_message" {
+  description = "Can be PR_BODY, PR_TITLE, or BLANK for a default merge commit message. Applicable only if allow_merge_commit is true."
+  type        = string
+  default     = null
+}
+
+variable "squash_merge_commit_title" {
+  description = "(Optional) Can be PR_TITLE or COMMIT_OR_PR_TITLE for a default squash merge commit title. Applicable only if allow_squash_merge is true."
+  type        = string
+  default     = null
+}
+
+variable "squash_merge_commit_message" {
+  description = "(Optional) Can be PR_BODY, COMMIT_MESSAGES, or BLANK for a default squash merge commit message. Applicable only if allow_squash_merge is true."
+  type        = string
+  default     = null
+}
+
 variable "extra_topics" {
   description = "(Optional) The list of additional topics of the repository. (Default: [])"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -279,29 +279,37 @@ variable "branch_protections" {
   type = map(
     object(
       {
-        allows_deletions                = optional(bool, false)
-        allows_force_pushes             = optional(bool, false)
-        blocks_creations                = optional(bool, false)
         enforce_admins                  = optional(bool, false)
-        push_restrictions               = optional(list(string), [])
-        require_conversation_resolution = optional(bool, false)
         require_signed_commits          = optional(bool, false)
         required_linear_history         = optional(bool, false)
-        required_pull_request_reviews = optional(object(
-          {
-            dismiss_stale_reviews           = optional(bool, false)
-            dismissal_restrictions          = optional(list(string), [])
-            pull_request_bypassers          = optional(list(string), [])
-            require_code_owner_reviews      = optional(bool, false)
-            required_approving_review_count = optional(number, 0)
-          }
-        ))
+        require_conversation_resolution = optional(bool, false)
         required_status_checks = optional(object(
           {
-            strict = optional(bool, false)
-            checks = optional(list(string), [])
+            strict   = optional(bool)
+            contexts = optional(list(string))
           }
         ))
+        required_pull_request_reviews = optional(object(
+          {
+            dismiss_stale_reviews           = optional(bool)
+            restrict_dismissals             = optional(bool)
+            dismissal_restrictions          = optional(list(string))
+            pull_request_bypassers          = optional(list(string))
+            require_code_owner_reviews      = optional(bool)
+            required_approving_review_count = optional(number)
+            require_last_push_approval      = optional(bool)
+          }
+        ))
+        restrict_pushes = optional(object(
+          {
+            blocks_creations = optional(bool)
+            push_allowances  = optional(list(string))
+          }
+        ))
+        force_push_bypassers = optional(list(string))
+        allows_deletions     = optional(bool, false)
+        allows_force_pushes  = optional(bool, false)
+        lock_branch          = optional(bool, false)
       }
     )
   )

--- a/versions.tf
+++ b/versions.tf
@@ -3,13 +3,13 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.7"
 
   # branch_protections_v3 are broken in >= 5.3
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.20, < 6.0"
+      version = "~> 6"
     }
   }
 }


### PR DESCRIPTION
I made this PR because the github v3 branch protections API breaks idempotency by showing a change on `contexts/checks` once applied, therefore tests were failing on my other PR.

Removes branch_protections_v3 and only uses v4

removes deprecated downloads feature

Removes a lot of try,catch in favor of using terraform variable defaults

BREAKING: restructures branch_protections into map instead of list(map)
BREAKING: removes downloads
BREAKING: upgrades providers, some properties for repository have been renamed on github's API
